### PR TITLE
add app_with_mock_cache fixture. Fix state changing test

### DIFF
--- a/tests/api/test_access_control.py
+++ b/tests/api/test_access_control.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 from flask import make_response
 from mohawk import Sender
@@ -18,6 +20,7 @@ def mock_endpoint():
 class TestAuthentication:
     @pytest.fixture(autouse=True)
     def setup(self, app_with_db, app_with_mock_cache):
+        original_config = copy.deepcopy(app_with_db.config)
         app_with_db.config['access_control'].update(
             {
                 'hawk_enabled': True,
@@ -43,6 +46,9 @@ class TestAuthentication:
             client_scope=self.client_scope,
             description=self.description,
         )
+        yield
+        HawkUsers.query.delete()
+        app_with_db.config = original_config
 
     def test_successful_authentication(self):
         sender = Sender(

--- a/tests/api/test_access_control.py
+++ b/tests/api/test_access_control.py
@@ -14,6 +14,7 @@ from app.db.models.internal import HawkUsers
 def mock_endpoint():
     return make_response('OK')
 
+
 class TestAuthentication:
     @pytest.fixture(autouse=True)
     def setup(self, app_with_db, app_with_mock_cache):
@@ -176,11 +177,10 @@ class TestAuthentication:
 
 
 class TestAuthorization:
-
     @pytest.fixture(autouse=True)
     def setup(self, app_with_hawk_user, app_with_mock_cache):
         self.app = app_with_hawk_user
-    
+
     def test_successful_authorization(self):
         sender = Sender(
             credentials={'id': 'iss1', 'key': 'secret1', 'algorithm': 'sha256'},

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -87,15 +87,10 @@ class TestToTabularWebDict(unittest.TestCase):
         self.assertEqual(output, expected)
 
 
-class TestResponseOrientationDecorator(unittest.TestCase):
-    @unittest.mock.patch('app.api.utils.request')
-    def test(self, request):
-        request.args.get.return_value = 'your orientation'
+def test_response_orientation_dectorator(app):
+    with app.test_request_context('/?orientation=your orientation'):
         view = unittest.mock.Mock(__name__='asdf')
         wrapped = utils.response_orientation_decorator(view)
-
-        self.assertEqual(wrapped.__name__, 'asdf')
-
+        assert wrapped.__name__ == 'asdf'
         wrapped()
-        request.args.get.assert_called_once_with('orientation', 'tabular')
         view.assert_called_once_with('your orientation')

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -78,7 +78,7 @@ def test_healthcheck_view(app_with_db):
     assert response.json == {'status': 'OK'}
 
 
-def test_get_ons_postcodes_when_no_data(app_with_hawk_user):
+def test_get_ons_postcodes_when_no_data(app_with_hawk_user, app_with_mock_cache):
     client = app_with_hawk_user.test_client()
     response = make_hawk_auth_request(client, '/api/v1/get-ons-postcodes/')
 
@@ -86,7 +86,7 @@ def test_get_ons_postcodes_when_no_data(app_with_hawk_user):
     assert response.json == {'headers': ONS_POSTCODE_FIELDS, 'next': None, 'values': []}
 
 
-def test_get_ons_postcodes(app_with_hawk_user, add_ons_postcode):
+def test_get_ons_postcodes(app_with_hawk_user, app_with_mock_cache, add_ons_postcode):
 
     postcode = 'AB1 1BA'
 
@@ -106,7 +106,7 @@ def test_get_ons_postcodes(app_with_hawk_user, add_ons_postcode):
     }
 
 
-def test_get_ons_postcodes_next_url(app_with_hawk_user, add_ons_postcode):
+def test_get_ons_postcodes_next_url(app_with_hawk_user, app_with_mock_cache, add_ons_postcode):
     app_with_hawk_user.config['app']['pagination_size'] = 1
     postcode_1 = 'AB1 1BA'
     postcode_2 = 'AB2 2BA'
@@ -126,7 +126,9 @@ def test_get_ons_postcodes_next_url(app_with_hawk_user, add_ons_postcode):
     }
 
 
-def test_get_ons_postcodes_when_next_id_specified(app_with_hawk_user, add_ons_postcode):
+def test_get_ons_postcodes_when_next_id_specified(
+        app_with_hawk_user, app_with_mock_cache, add_ons_postcode
+):
     app_with_hawk_user.config['app']['pagination_size'] = 1
     postcode_1 = 'AB1 1BA'
     postcode_2 = 'AB2 2BA'

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -127,7 +127,7 @@ def test_get_ons_postcodes_next_url(app_with_hawk_user, app_with_mock_cache, add
 
 
 def test_get_ons_postcodes_when_next_id_specified(
-        app_with_hawk_user, app_with_mock_cache, add_ons_postcode
+    app_with_hawk_user, app_with_mock_cache, add_ons_postcode
 ):
     app_with_hawk_user.config['app']['pagination_size'] = 1
     postcode_1 = 'AB1 1BA'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def app_with_hawk_user(app_with_db):
     app_with_db.config['access_control'].update(
         {
             'hawk_enabled': True,
-            'hawk_nonce_enabled': False,
+            'hawk_nonce_enabled': True,
             'hawk_algorithm': 'sha256',
             'hawk_accept_untrusted_content': True,
             'hawk_localtime_offset_in_seconds': 0,
@@ -88,6 +88,29 @@ def app_with_hawk_user(app_with_db):
         description='test authorization 3',
     )
     yield app_with_db
+
+    
+@pytest.fixture
+def app_with_mock_cache(app):
+
+    class CacheMock:
+        cache = {}
+
+        def set(self, key, value, ex):
+            self.cache[key] = value
+            
+        def get(self, key):
+            return self.cache.get(key, None)
+
+    app_has_cache = hasattr(app, 'cache')
+    if app_has_cache:
+        original_cache = app
+    app.cache = CacheMock()
+    yield
+    if app_has_cache:
+        app.cache = original_cache
+    else:
+        del app.cache
 
 
 def _create_testing_db_name():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,16 +89,15 @@ def app_with_hawk_user(app_with_db):
     )
     yield app_with_db
 
-    
+
 @pytest.fixture
 def app_with_mock_cache(app):
-
     class CacheMock:
         cache = {}
 
         def set(self, key, value, ex):
             self.cache[key] = value
-            
+
         def get(self, key):
             return self.cache.get(key, None)
 


### PR DESCRIPTION
"issues"

* do we need to add an integrated test to test a real redis server instance instead of using the mock cache? I actually think the mock cache is fine and we don't need to do this because I think our get and set implementations are quite simple. On the other hand setting up a fixture to connect to and reset a redis instance is not that much work

https://github.com/uktrade/data-store-service/blob/develop/app/api/views.py#L38

* we can also combine the `app_with_hawk_user` and `app_with_mock_cache` or make the former use the latter if they are going to be used together all the time, but it would make our fixtures a little less flexible for future weird combinations of fixtures