### PR TITLE
Selected products option for world bank tariff pipelines

### DIFF
--- a/app/commands/dev/datafiles_to_db_by_source.py
+++ b/app/commands/dev/datafiles_to_db_by_source.py
@@ -56,6 +56,7 @@ exclude_pipelines = [
 @click.option('--all', is_flag=True, help='ingest datafile into the DB')
 @click.option('--force', is_flag=True, help='Force pipeline')
 @click.option('--continue', is_flag=True, help='Continue transform')
+@click.option('--products', type=str, help='Only process selected products', default=None)
 def datafiles_to_db_by_source(**kwargs):
     """
     Populate tables with source files
@@ -74,6 +75,7 @@ def datafiles_to_db_by_source(**kwargs):
                         sub_directory=sub_dir,
                         force=kwargs['force'],
                         continue_transform=kwargs['continue'],
+                        products=kwargs['products'],
                     )
         manager.pipeline_process_all()
 

--- a/app/commands/dev/datafiles_to_db_by_source.py
+++ b/app/commands/dev/datafiles_to_db_by_source.py
@@ -55,8 +55,15 @@ exclude_pipelines = [
 @with_appcontext
 @click.option('--all', is_flag=True, help='ingest datafile into the DB')
 @click.option('--force', is_flag=True, help='Force pipeline')
-@click.option('--continue', is_flag=True, help='Continue transform')
-@click.option('--products', type=str, help='Only process selected products', default=None)
+@click.option(
+    '--continue', is_flag=True, help='Continue transform [World bank tariff pipelines ' 'only]'
+)
+@click.option(
+    '--products',
+    type=str,
+    help='Only process selected products [World bank tariff ' 'pipelines only]',
+    default=None,
+)
 def datafiles_to_db_by_source(**kwargs):
     """
     Populate tables with source files

--- a/app/etl/etl_base.py
+++ b/app/etl/etl_base.py
@@ -1,5 +1,6 @@
 import re
 from abc import ABCMeta, abstractmethod
+from collections import namedtuple
 
 from flask import current_app as flask_app
 
@@ -38,6 +39,14 @@ class DataPipeline(metaclass=ABCMeta):
     L1_TABLE = 'L1'
     L2_TABLE = 'L2'
 
+    def set_option_defaults(self, options):
+        options.setdefault('force', False)
+        return options
+
+    def get_options(self, options):
+        options = self.set_option_defaults(options)
+        return namedtuple('Options', options.keys())(*options.values())
+
     @property
     def l1_helper_columns(self):
         return [
@@ -45,10 +54,9 @@ class DataPipeline(metaclass=ABCMeta):
             ('data_source_row_id', 'int'),  # reference to L0 id column
         ]
 
-    def __init__(self, dbi, force=False, continue_transform=False):
+    def __init__(self, dbi, **kwargs):
         self.dbi = dbi
-        self.force = force
-        self.continue_transform = continue_transform
+        self.options = self.get_options(kwargs)
         if not dbi:
             flask_app.logger.error(
                 f'warning: dbi ({dbi}) is not valid; '

--- a/app/etl/etl_incremental_data.py
+++ b/app/etl/etl_incremental_data.py
@@ -67,11 +67,10 @@ class IncrementalDataPipeline(DataPipeline):
         return self.l1_helper_columns + self._l1_data_column_types
 
     def create_tables(self):
-        self._create_sequence(self._l0_sequence, drop_existing=self.force)
-        self._create_sequence(self._l1_sequence, drop_existing=self.force)
-
-        self._create_table(self._l0_table, self._l0_column_types, drop_existing=self.force)
-        self._create_table(self._l1_table, self._l1_column_types, drop_existing=self.force)
+        self._create_sequence(self._l0_sequence, drop_existing=self.options.force)
+        self._create_sequence(self._l1_sequence, drop_existing=self.options.force)
+        self._create_table(self._l0_table, self._l0_column_types, drop_existing=self.options.force)
+        self._create_table(self._l1_table, self._l1_column_types, drop_existing=self.options.force)
         self._create_table(self._l0_temp_table, self._l0_column_types, drop_existing=True)
         self._create_table(self._l1_temp_table, self._l1_column_types, drop_existing=True)
 

--- a/app/etl/etl_world_bank_tariff.py
+++ b/app/etl/etl_world_bank_tariff.py
@@ -177,8 +177,6 @@ class WorldBankTariffTransformPipeline(IncrementalDataPipeline):
                     where_clauses.append(f"product in {tuple(products)}")
             if where_clauses:
                 where = 'where ' + ' and '.join(where_clauses)
-
-        print(where)
         return where
 
     def _get_products(self):

--- a/app/etl/manager.py
+++ b/app/etl/manager.py
@@ -104,9 +104,7 @@ class Manager:
             progress.set_description(pipeline_id)
             self.pipeline_process(pipeline_id, progress_bar=progress)
 
-    def pipeline_register(
-        self, pipeline, sub_directory=None, pipeline_id=None, force=False, continue_transform=False
-    ):
+    def pipeline_register(self, pipeline, sub_directory=None, pipeline_id=None, **kwargs):
         """ Register a clean pipeline for the manager to use
 
         Args:
@@ -124,15 +122,12 @@ class Manager:
         Returns:
             None
         """
-        po = (
-            pipeline(dbi=self.dbi, force=force, continue_transform=continue_transform)
-            if inspect.isclass(pipeline)
-            else pipeline
-        )
+        po = pipeline(dbi=self.dbi, **kwargs) if inspect.isclass(pipeline) else pipeline
 
         pipeline_id = pipeline_id or po.id
         if pipeline_id in self._pipelines:
             raise ValueError(f'{po.id} pipeline is already registered')
+        force = kwargs.get('force', False)
         self._pipelines[pipeline_id] = PipelineConfig(po, sub_directory, force)
 
     def pipeline_remove(self, pipeline):

--- a/tests/commands/dev/test_datafiles_to_db_by_source.py
+++ b/tests/commands/dev/test_datafiles_to_db_by_source.py
@@ -1,0 +1,192 @@
+from unittest import mock
+
+import pytest
+
+from app.commands.dev.datafiles_to_db_by_source import (
+    ComtradeCountryCodeAndISOPipeline,
+    datafiles_to_db_by_source,
+    DITEUCountryMembershipPipeline,
+    DITReferencePostcodesPipeline,
+    ONSPostcodeDirectoryPipeline,
+    WorldBankBoundRatesPipeline,
+    WorldBankTariffPipeline,
+    WorldBankTariffTestPipeline,
+    WorldBankTariffTransformPipeline,
+    WorldBankTariffTransformTestPipeline,
+)
+
+
+class TestDataFileToDBBySource:
+    def test_cmd_help(self, app_with_db):
+        runner = app_with_db.test_cli_runner()
+        result = runner.invoke(datafiles_to_db_by_source)
+        assert 'Populate tables with source files' in result.output
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    @pytest.mark.parametrize(
+        'args,pipeline_register_calls,process_called,expected_msg',
+        (
+            (
+                ['--all'],
+                [
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'ons/postcode_directory/',
+                        'pipeline': ONSPostcodeDirectoryPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'dit/reference_postcodes',
+                        'pipeline': DITReferencePostcodesPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'world_bank/tariff',
+                        'pipeline': WorldBankTariffPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'dit/eu_country_membership',
+                        'pipeline': DITEUCountryMembershipPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'comtrade/country_code_and_iso',
+                        'pipeline': ComtradeCountryCodeAndISOPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'world_bank/bound_rates',
+                        'pipeline': WorldBankBoundRatesPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': None,
+                        'pipeline': WorldBankTariffTransformPipeline,
+                    },
+                ],
+                True,
+                None,
+            ),
+            (
+                ['--world_bank.test'],
+                [
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'world_bank/test',
+                        'pipeline': WorldBankTariffTestPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': None,
+                        'pipeline': WorldBankTariffTransformTestPipeline,
+                    },
+                ],
+                True,
+                None,
+            ),
+            (
+                ['--ons.postcode_directory', '--force'],
+                [
+                    {
+                        'continue_transform': False,
+                        'force': True,
+                        'products': None,
+                        'sub_directory': 'ons/postcode_directory/',
+                        'pipeline': ONSPostcodeDirectoryPipeline,
+                    },
+                ],
+                True,
+                None,
+            ),
+            (
+                ['--world_bank.test', '--continue'],
+                [
+                    {
+                        'continue_transform': True,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': 'world_bank/test',
+                        'pipeline': WorldBankTariffTestPipeline,
+                    },
+                    {
+                        'continue_transform': True,
+                        'force': False,
+                        'products': None,
+                        'sub_directory': None,
+                        'pipeline': WorldBankTariffTransformTestPipeline,
+                    },
+                ],
+                True,
+                None,
+            ),
+            (
+                ['--world_bank.test', '--products', '1234,5623'],
+                [
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': '1234,5623',
+                        'sub_directory': 'world_bank/test',
+                        'pipeline': WorldBankTariffTestPipeline,
+                    },
+                    {
+                        'continue_transform': False,
+                        'force': False,
+                        'products': '1234,5623',
+                        'sub_directory': None,
+                        'pipeline': WorldBankTariffTransformTestPipeline,
+                    },
+                ],
+                True,
+                None,
+            ),
+            ([], None, False, 'Populate tables with source file'),
+        ),
+    )
+    @mock.patch('app.etl.manager.Manager.pipeline_register')
+    @mock.patch('app.etl.manager.Manager.pipeline_process_all')
+    def test_cmd(
+        self,
+        mock_process_all,
+        mock_pipeline_register,
+        app_with_db,
+        args,
+        pipeline_register_calls,
+        process_called,
+        expected_msg,
+    ):
+        mock_pipeline_register.return_value = None
+        mock_process_all.return_value = None
+        runner = app_with_db.test_cli_runner()
+        result = runner.invoke(datafiles_to_db_by_source, args)
+
+        if pipeline_register_calls:
+            assert mock_pipeline_register.called is True
+            for parameters in pipeline_register_calls:
+                mock_pipeline_register.assert_any_call(**parameters)
+            assert mock_pipeline_register.call_count is len(pipeline_register_calls)
+        else:
+            assert mock_pipeline_register.called is False
+        assert mock_process_all.called is process_called
+        if expected_msg:
+            assert expected_msg in result.output

--- a/tests/etl/test_dit_reference_postcodes.py
+++ b/tests/etl/test_dit_reference_postcodes.py
@@ -8,7 +8,7 @@ snapshot1 = 'tests/fixtures/dit/reference_postcodes/snapshot1.csv'
 
 class TestDITReferencePostcodesPipeline:
     def test_one_datafile(self, app_with_db):
-        pipeline = DITReferencePostcodesPipeline(app_with_db.dbi, False)
+        pipeline = DITReferencePostcodesPipeline(app_with_db.dbi, force=False)
         fi = FileInfo.from_path(snapshot1)
         pipeline.process(fi)
         expected_rows = [

--- a/tests/etl/test_ons_postcode_directory.py
+++ b/tests/etl/test_ons_postcode_directory.py
@@ -9,7 +9,7 @@ snapshot2 = 'tests/fixtures/ons/postcode_directory/ONSPD_JUL_2019_UK.csv'
 
 class TestONSPostcodeDirectoryPipeline:
     def test_one_datafile(self, app_with_db):
-        pipeline = ONSPostcodeDirectoryPipeline(app_with_db.dbi, False)
+        pipeline = ONSPostcodeDirectoryPipeline(app_with_db.dbi, force=False)
         fi = FileInfo.from_path(snapshot1)
         pipeline.process(fi)
 
@@ -232,7 +232,7 @@ class TestONSPostcodeDirectoryPipeline:
         assert rows_equal_table(app_with_db.dbi, expected_rows, pipeline._l1_table, pipeline)
 
     def test_same_data(self, app_with_db):
-        pipeline = ONSPostcodeDirectoryPipeline(app_with_db.dbi, False)
+        pipeline = ONSPostcodeDirectoryPipeline(app_with_db.dbi, force=False)
         fi = FileInfo.from_path(snapshot1)
         pipeline.process(fi)
         fi.data.seek(0)
@@ -458,7 +458,7 @@ class TestONSPostcodeDirectoryPipeline:
         assert rows_equal_table(app_with_db.dbi, expected_rows, pipeline._l1_table, pipeline)
 
     def test_new_data(self, app_with_db):
-        pipeline = ONSPostcodeDirectoryPipeline(app_with_db.dbi, False)
+        pipeline = ONSPostcodeDirectoryPipeline(app_with_db.dbi, force=False)
         fi = FileInfo.from_path(snapshot1)
         pipeline.process(fi, delete_previous=True)
         fi2 = FileInfo.from_path(snapshot2)

--- a/tests/etl/test_world_bank_tariff.py
+++ b/tests/etl/test_world_bank_tariff.py
@@ -86,7 +86,7 @@ class TestWorldBankTariffPipeline:
         add_world_bank_bound_rates(bound_rates)
 
     def test_pipeline(self):
-        pipeline = WorldBankTariffPipeline(self.dbi, True)
+        pipeline = WorldBankTariffPipeline(self.dbi, force=True)
         fi = FileInfo.from_path(file_1)
         pipeline.process(fi)
 
@@ -96,7 +96,7 @@ class TestWorldBankTariffPipeline:
         assert rows_equal_table(self.dbi, expected_rows, pipeline._l0_table, pipeline, top_rows=1)
 
         # check L1
-        pipeline = WorldBankTariffTransformPipeline(self.dbi, True)
+        pipeline = WorldBankTariffTransformPipeline(self.dbi, force=True)
         pipeline.process()
         assert rows_equal_table(self.dbi, [], pipeline._l1_table, pipeline, top_rows=1)
 
@@ -171,10 +171,10 @@ class TestWorldBankTariffPipeline:
         ),
     )
     def test_transform_of_datafile(self, file_name, years, expected_rows):
-        pipeline = WorldBankTariffPipeline(self.dbi, True)
+        pipeline = WorldBankTariffPipeline(self.dbi, force=True)
         fi = FileInfo.from_path(file_name)
         pipeline.process(fi)
-        pipeline = WorldBankTariffTransformPipeline(self.dbi, True)
+        pipeline = WorldBankTariffTransformPipeline(self.dbi, force=True)
         pipeline.process()
         assert rows_equal_table(self.dbi, expected_rows, pipeline._l1_table, pipeline)
 
@@ -192,12 +192,14 @@ class TestWorldBankTariffPipeline:
         ) as mock_get_products:
             mock_get_products.return_value = [['301'], ['401']]
 
-            pipeline = WorldBankTariffTransformPipeline(self.dbi, False, continue_transform)
+            pipeline = WorldBankTariffTransformPipeline(
+                self.dbi, force=False, continue_transform=continue_transform
+            )
             pipeline.process()
             assert rows_equal_table(self.dbi, expected_rows, pipeline._l1_table, pipeline,)
 
     def partial_transform_data(self):
-        pipeline = WorldBankTariffPipeline(self.dbi, True)
+        pipeline = WorldBankTariffPipeline(self.dbi, force=True)
         fi = FileInfo.from_path(country_to_country_three_products)
         pipeline.process(fi)
 
@@ -210,7 +212,9 @@ class TestWorldBankTariffPipeline:
             ) as mock_finish_processing:
                 mock_finish_processing.return_value = None
 
-                pipeline = WorldBankTariffTransformPipeline(self.dbi, False, True)
+                pipeline = WorldBankTariffTransformPipeline(
+                    self.dbi, force=False, continue_transform=True
+                )
                 pipeline.process()
                 assert rows_equal_table(
                     self.dbi, PRODUCT_201_ROWS, pipeline._l1_temp_table, pipeline


### PR DESCRIPTION
To test:
 - Run `./manage.py dev datafiles_to_db_by_source --world_bank.bulk --products 10129,1061`

Check only those two products appear in the database.

Note:
I've left the other two pipelines for now and will remove at a later date.


