### PR TITLE
Command to dump and populate spire schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ app/config/local.yml
 
 # npm
 node_modules/
+
+.csv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ADD requirements.txt /tmp/requirements.txt
 
 ADD scripts scripts
 RUN scripts/install_dockerize.sh
+RUN scripts/install_psql_client.sh
 RUN scripts/install_python_packages.sh
 
 WORKDIR /app

--- a/app/commands/dev/__init__.py
+++ b/app/commands/dev/__init__.py
@@ -6,6 +6,10 @@ from app.commands.dev.datafiles_to_db_by_source import (
 )
 from app.commands.dev.db import db as db_command
 from app.commands.dev.s3 import s3 as s3_command
+from app.commands.dev.spire import (
+    dump_spire_schema as dump_spire_schema_command,
+    populate_spire_schema as populate_spire_schema_command,
+)
 
 
 cmd_group = AppGroup('dev', help='Commands to build database')
@@ -14,3 +18,5 @@ cmd_group.add_command(add_hawk_user_command)
 cmd_group.add_command(datafiles_command)
 cmd_group.add_command(db_command)
 cmd_group.add_command(s3_command)
+cmd_group.add_command(dump_spire_schema_command)
+cmd_group.add_command(populate_spire_schema_command)

--- a/app/commands/dev/spire.py
+++ b/app/commands/dev/spire.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+
+import click
+from flask import current_app as app
+from flask.cli import with_appcontext
+
+from app.db.models.external import SPIRE_SCHEMA_NAME
+
+
+FOLDER = f'{os.getcwd()}/.csv/spire'
+
+GET_TABLES_IN_SCHEMA_SQL = "select tablename from pg_tables where schemaname='{schema_name}'"
+
+
+def get_table_names(schema_name):
+    tables = app.dbi.execute_query(GET_TABLES_IN_SCHEMA_SQL.format(schema_name=schema_name))
+    return [table for table, in tables]
+
+
+def make_data_dir():
+    os.makedirs(FOLDER, exist_ok=True)
+
+
+@click.command('dump_spire_schema')
+@with_appcontext
+def dump_spire_schema():
+    """
+    Dump spire schema
+    """
+    name = SPIRE_SCHEMA_NAME
+    db_uri = app.config['SQLALCHEMY_DATABASE_URI']
+    make_data_dir()
+    for table in get_table_names(name):
+        dump_sql = (
+            f"""\COPY \\"{name}\\".\\"{table}\\" to '{FOLDER}/{table.upper()}.csv' """
+            f"WITH ("
+            f"FORMAT "
+            f"CSV, HEADER)"
+        )  # noqa: W605
+        cmd = f'psql {db_uri} -c "{dump_sql}"'
+        click.echo(f'Creating {table.upper()}.csv')
+        subprocess.run(cmd, shell=True)
+
+
+@click.command('populate_spire_schema')
+@with_appcontext
+@click.option(
+    '--batch_size', type=int, help='Batch size', default=10,
+)
+def populate_spire_schema(batch_size):
+
+    """
+    Populate spire schema
+    """
+    click.echo('Populating schema')
+    populate_country_mapping(batch_size)
+    app.db.session.commit()
+
+
+def populate_country_mapping(batch_size):
+    click.echo('- Adding country data')
+    from tests.fixtures.factories import SPIRECountryGroupFactory, SPIRERefCountryMappingFactory
+
+    batch = []
+
+    batch_group = SPIRECountryGroupFactory.create_batch(size=batch_size)
+
+    country_mappings = SPIRERefCountryMappingFactory.create_batch(
+        size=batch_size, country_groups=[batch_group[0]]
+    )
+    batch.extend(country_mappings)
+    batch.extend(batch_group)
+
+    for _country_model in batch:
+        app.db.session.add(_country_model)

--- a/app/db/models/external.py
+++ b/app/db/models/external.py
@@ -4,6 +4,7 @@ from data_engineering.common.db.models import (
     _decimal,
     _foreign_key,
     _int,
+    _relationship,
     _table,
     _text,
     BaseModel,
@@ -238,6 +239,14 @@ class DITBACIL1(BaseModel):
 SPIRE_SCHEMA_NAME = 'dit.spire'
 
 
+spire_country_group_entry = _table(
+    'country_group_entry',
+    _col('cg_id', _int, _foreign_key(f'{SPIRE_SCHEMA_NAME}.country_group.id')),
+    _col('country_id', _int, _foreign_key(f'{SPIRE_SCHEMA_NAME}.ref_country_mapping.country_id')),
+    schema=SPIRE_SCHEMA_NAME,
+)
+
+
 class SPIRECountryGroup(BaseModel):
     __tablename__ = f'country_group'
     __table_args__ = {'schema': SPIRE_SCHEMA_NAME}
@@ -251,11 +260,4 @@ class SPIRERefCountryMapping(BaseModel):
 
     country_id = _col(_int, primary_key=True, autoincrement=True)
     country_name = _col(_text)
-
-
-spire_country_group_entry = _table(
-    'country_group_entry',
-    _col('cg_id', _int, _foreign_key(f'{SPIRE_SCHEMA_NAME}.country_group.id')),
-    _col('country_id', _int, _foreign_key(f'{SPIRE_SCHEMA_NAME}.ref_country_mapping.country_id')),
-    schema=SPIRE_SCHEMA_NAME,
-)
+    country_groups = _relationship("SPIRECountryGroup", secondary=spire_country_group_entry)

--- a/requirements.in
+++ b/requirements.in
@@ -33,3 +33,4 @@ sqlalchemy==1.3.16
 toolz==0.10.0
 watchdog==0.10.2
 werkzeug==1.0.1
+factory_boy==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ git+https://github.com/uktrade/data-engineering-common.git  # via -r requirement
 decorator==4.4.1          # via ipython, traitlets
 docutils==0.15.2          # via botocore
 entrypoints==0.3          # via flake8
+factory_boy==2.12.0       # via -r requirements.in
+faker==4.0.3              # via factory-boy
 flake8-import-order==0.18.1  # via -r requirements.in, data-engineering-common
 flake8==3.7.9             # via -r requirements.in, data-engineering-common
 flask-babelex==0.9.3      # via flask-security
@@ -83,7 +85,7 @@ pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements.in, data-engineering-common
 pytest-mock==3.0.0        # via -r requirements.in
 pytest==5.4.1             # via -r requirements.in, data-engineering-common, pytest-cov, pytest-mock
-python-dateutil==2.8.1    # via alembic, botocore, freezegun, pandas
+python-dateutil==2.8.1    # via alembic, botocore, faker, freezegun, pandas
 python-dotenv==0.12.0     # via data-engineering-common
 python-editor==1.0.4      # via alembic
 pytz==2019.3              # via apscheduler, babel, pandas, tzlocal
@@ -99,6 +101,7 @@ speaklater==1.3           # via flask-babelex
 sqlalchemy-utils==0.36.3  # via -r requirements.in, data-engineering-common
 sqlalchemy==1.3.16        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-utils
 srsly==1.0.2              # via spacy, thinc
+text-unidecode==1.3       # via faker
 thinc==7.4.0              # via spacy
 toml==0.10.0              # via black
 toolz==0.10.0             # via -r requirements.in

--- a/scripts/install_psql_client.sh
+++ b/scripts/install_psql_client.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./scripts/functions.sh
+
+run "apt-get install -y postgresql-client"

--- a/scripts/install_python_packages.sh
+++ b/scripts/install_python_packages.sh
@@ -3,4 +3,4 @@
 source ./scripts/functions.sh
 
 run "pip install --upgrade pip"
-run 'pip install -r /tmp/requirements.txt'
+run 'pip install -r /tmp/requirements.txt --no-cache-dir'

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,0 +1,34 @@
+import factory
+from flask import current_app as app
+
+from app.db.models.external import (
+    SPIRECountryGroup,
+    SPIRERefCountryMapping,
+)
+
+
+class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        abstract = True
+        sqlalchemy_session = app.db.session
+
+
+class SPIRECountryGroupFactory(BaseFactory):
+    class Meta:
+        model = SPIRECountryGroup
+
+
+class SPIRERefCountryMappingFactory(BaseFactory):
+    country_name = factory.Faker('word')
+
+    class Meta:
+        model = SPIRERefCountryMapping
+
+    @factory.post_generation
+    def country_groups(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            for country_group in extracted:
+                self.country_groups.append(country_group)


### PR DESCRIPTION
Here is the initial command to populate (with tests data) and dump the spire schema

The dump command dumps all tables within the schema into csv files. This will be used to generate the test data csv files. It also has scope to be changed into a more generic command where any schema could be dumped.

The populate command is the foundations for how test data will be created using factory boy.
As more models get added this command will grow.

To test (psql is required)
 - `./scripts/install_psql_client.sh`
 - `./manage.py dev populate_spire_schema  --batch_size 100`
 - Check database tables have been populated
 - `/manage.py dev dump_spire_schema` 
 - Check folder .csv/spire for csv files

Consider this first part tests and refactoring to follow and a process of using the factories within the tests themselves.