### PR TITLE
Fix no postcode specified in search request

### DIFF
--- a/app/api/views/dit_reference_postcodes.py
+++ b/app/api/views/dit_reference_postcodes.py
@@ -3,6 +3,7 @@ from data_engineering.common.views import ac, json_error
 from flask import current_app as flask_app
 from flask import request
 from flask.views import View
+from werkzeug.exceptions import BadRequest
 
 from app.api.views.base import PipelinePaginatedListView
 from app.db.models.external import DITReferencePostcodesL1
@@ -22,8 +23,10 @@ class DitReferencePostcodeView(View):
     model = DITReferencePostcodesL1
 
     def dispatch_request(self):
-        postcode = request.args.get('postcode')
         orientation = request.args.get('orientation', 'tabular')
+        postcode = request.args.get('postcode')
+        if not postcode:
+            raise BadRequest('No postcode specified')
         postcode = postcode.replace(' ', '').lower()
         sql_query = f'''
             select {','.join(

--- a/tests/api/views/test_get_dit_reference_postcode.py
+++ b/tests/api/views/test_get_dit_reference_postcode.py
@@ -23,6 +23,16 @@ def test_get_dit_reference_postcode_when_no_data(app_with_hawk_user, app_with_mo
     assert response.json['values'] == []
 
 
+def test_get_dit_reference_postcode_when_no_param_specified(
+    app_with_hawk_user, app_with_mock_cache
+):
+    url = '/api/v1/get-dit-reference-postcode/'
+    client = app_with_hawk_user.test_client()
+    response = make_hawk_auth_request(client, url)
+    assert response.status_code == 400
+    assert response.json['error'] == 'No postcode specified'
+
+
 def test_get_dit_reference_postcode(
     add_dit_reference_postcodes, app_with_hawk_user, app_with_mock_cache
 ):


### PR DESCRIPTION
This fixes the issue when no postcode is specified on the `get-postcode-data` endpoint.

Before fix an internal server error is raised