### PR TITLE
Set gunicorn server header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ compile_assets:
 
 .PHONY: run_server
 run_server: compile_assets
-	exec gunicorn 'data_engineering.common.application:get_or_create()' -b 0.0.0.0:${PORT} --config 'app/config/gunicorn.conf'
+	exec gunicorn 'data_engineering.common.application:get_or_create()' -b 0.0.0.0:${PORT} --config 'app/config/gunicorn_config.py'
 
 
 .PHONY: run_dev_server

--- a/app/config/gunicorn_config.py
+++ b/app/config/gunicorn_config.py
@@ -1,10 +1,13 @@
-import os
 import multiprocessing
+import os
+
+import gunicorn
 
 recommended_amount_of_workers = (multiprocessing.cpu_count() * 2) + 1
 workers = os.environ.get('GUNICORN_WORKERS', recommended_amount_of_workers)
 
 proc_name = 'data-store-service'
+gunicorn.SERVER_SOFTWARE = proc_name
 
 forwarded_allow_ips = '*'
 x_forwarded_for_header = 'X-FORWARDED-FOR'
@@ -13,4 +16,3 @@ secure_scheme_headers = {
 }
 timeout = 120
 keepalive = 20
-


### PR DESCRIPTION
This sets the gunicorn header rather than showing which version is being used.

<img width="359" alt="Screenshot 2020-06-12 at 14 48 07" src="https://user-images.githubusercontent.com/8222658/84510270-d2e0d300-acbc-11ea-974e-5e128808fdca.png">

To test make sure your set up uses  the `make run_server` command rather than the dev alternative. 

Go to a page and check the response headers 