### PR TITLE
show dw schema and table and improve input validation

### DIFF
--- a/app/uploader/forms.py
+++ b/app/uploader/forms.py
@@ -16,13 +16,16 @@ class PipelineForm(FlaskForm):
         'Dataset', validators=[DataRequired()], render_kw={'class': 'govuk-input'}
     )
 
+    def format(self, field):
+        return field.lower().replace('.', '_')
+
     def validate(self):
         rv = FlaskForm.validate(self)
         if not rv:
             return False
 
         pipeline = Pipeline.query.filter_by(
-            organisation=self.organisation.data, dataset=self.dataset.data
+            organisation=self.format(self.organisation.data), dataset=self.format(self.dataset.data)
         ).first()
         if pipeline is not None:
             self.errors['non_field_errors'] = [

--- a/app/uploader/templates/pipeline_data_uploaded.html
+++ b/app/uploader/templates/pipeline_data_uploaded.html
@@ -5,7 +5,8 @@
     <h1 class="govuk-panel__title">Data now being processed</h1>
     <div class="govuk-panel__body">by&nbsp;<strong>{{ pipeline }}</strong>&nbsp;pipeline</div>
     <div id="pipeline_progress_label" class="govuk-panel__body">Please wait</div>
-    <progress id="pipeline_progress" value="0" max="100"/>
+    <progress id="pipeline_progress" value="0" max="100"></progress>
+    <p id="pipeline_info" class="govuk-panel__body"></p>
 </div>
 <script type="text/javascript">
 function loadXMLDoc(file_id, interval) {
@@ -17,7 +18,10 @@ function loadXMLDoc(file_id, interval) {
                document.getElementById("pipeline_progress").value = xmlhttp.responseText;
                if (xmlhttp.responseText == 100) {
                     clearInterval(interval);
-                    document.getElementById("pipeline_progress_label").innerHTML = 'Completed';
+                    document.getElementById("pipeline_progress_label").innerHTML = 'Completed!';
+                    document.getElementById("pipeline_info").innerHTML = 'The data will \
+                     be available in Data Workspace in table "{{ data_workspace_table_name }}" \
+                     under schema "{{ data_workspace_schema_name }}"';
                }
            }
            else {


### PR DESCRIPTION
- show schema and table name in data workspace at the end of the user journey
- take capitalisation into account on finding existing pipelines
- replace dots from org/dataset names