### PR TITLE
 Fix id for pipeline select radio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ node_modules/
 static/dist/
 
 .csv/
+
+inputs/

--- a/app/uploader/templates/form/input_radio_field.html
+++ b/app/uploader/templates/form/input_radio_field.html
@@ -6,8 +6,8 @@
     <div class="govuk-radios">
         {% for choice in field  %}
             <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="{{ choice.name }}" name="{{ choice.name }}" type="radio" value="{{ choice.data }}">
-                <label class="govuk-label govuk-radios__label" for="{{ choice.name }}">
+                <input class="govuk-radios__input" id="{{ choice.id }}" name="{{ choice.name }}" type="radio" value="{{ choice.data }}">
+                <label class="govuk-label govuk-radios__label" for="{{ choice.id }}">
                     {{ choice.label.text }}
                 </label>
             </div>

--- a/tests/uploader/test_views.py
+++ b/tests/uploader/test_views.py
@@ -79,6 +79,20 @@ def test_get_select_pipeline_view_with_pipelines(is_authenticated, app_with_db, 
 
 
 @mock.patch('data_engineering.common.sso.token.is_authenticated', return_value=True)
+def test_select_pipeline_view_radios_have_distinct_ids(is_authenticated, app_with_db, captured_templates):
+    PipelineFactory()
+    PipelineFactory()
+    client = get_client(app_with_db)
+    url = url_for('uploader_views.pipeline_select')
+    response, template_context = _test_view(
+        client, url, 'pipeline_select.html', captured_templates,
+    )
+    html = response.get_data(as_text=True)
+    assert '<input class="govuk-radios__input" id="pipeline-0" name="pipeline" type="radio" value="1">' in html
+    assert '<input class="govuk-radios__input" id="pipeline-1" name="pipeline" type="radio" value="2">' in html
+
+
+@mock.patch('data_engineering.common.sso.token.is_authenticated', return_value=True)
 def test_submit_form_select_pipeline_view(is_authenticated, app_with_db, captured_templates):
     pipeline = PipelineFactory()
     client = get_client(app_with_db)


### PR DESCRIPTION
At the moment all of the radio inputs and labels have the same id -
`pipeline`. This means that clicking on the label of any radio button
will select the first radio in the list, because that's the first
element with the `pipeline` id. Let's use the proper ID.