### PR TITLE
Don't `npm install` when deploying to PaaS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ WORKDIR /app
 
 COPY . /app
 
+RUN npm install
 CMD /app/scripts/entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,14 @@ COV ?= --cov
 BLACK_CONFIG ?= --exclude=venv --exclude=node_modules --skip-string-normalization --line-length 100
 CHECK ?= --check
 
+npm_install:
+	npm install
+
 compile_assets:
 	./scripts/compile_assets.sh
 
 .PHONY: run_server
-run_server: compile_assets
+run_server: npm_install compile_assets
 	exec gunicorn 'data_engineering.common.application:get_or_create()' -b 0.0.0.0:${PORT} --config 'app/config/gunicorn_config.py'
 
 

--- a/scripts/compile_assets.sh
+++ b/scripts/compile_assets.sh
@@ -2,5 +2,4 @@
 
 source ./scripts/functions.sh
 
-run "npm install"
 run "npm run-script build"


### PR DESCRIPTION
PaaS will automatically install the dependencies we need during the
staging process of the app when we deploy to PaaS. If we npm install
ourselves, it can sometimes be so slow that our app doesn't respond to
the healthcheck in time and so never becomes healthy.