### PR TITLE
Don't npm install on paas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,19 @@ FROM python:3.6
 
 RUN apt-get update -y
 
-ADD requirements.txt /tmp/requirements.txt
-
 ADD scripts scripts
 RUN scripts/install_dockerize.sh
 RUN scripts/install_psql_client.sh
+
+ADD requirements.txt /tmp/requirements.txt
+ADD package.json package-lock.json ./
+
 RUN scripts/install_python_packages.sh
 RUN scripts/install_node.sh
+RUN npm install
 
 WORKDIR /app
 
 COPY . /app
 
-RUN npm install
 CMD /app/scripts/entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,11 @@ COV ?= --cov
 BLACK_CONFIG ?= --exclude=venv --exclude=node_modules --skip-string-normalization --line-length 100
 CHECK ?= --check
 
-npm_install:
-	npm install
-
 compile_assets:
 	./scripts/compile_assets.sh
 
 .PHONY: run_server
-run_server: npm_install compile_assets
+run_server: compile_assets
 	exec gunicorn 'data_engineering.common.application:get_or_create()' -b 0.0.0.0:${PORT} --config 'app/config/gunicorn_config.py'
 
 


### PR DESCRIPTION
Accidentally left the `npm install` in the paas deployment. Fix that, and also optimise the Dockerfile slightly for better caching.