### PR TITLE
Add extra validation for uploaded data

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -17,6 +17,7 @@ def register_app_components(flask_app):
 
     if os.environ.get('NO_BROWSER_CACHE'):
         no_browser_cache(flask_app)
+
     return flask_app
 
 

--- a/app/uploader/templates/form/input_radio_field.html
+++ b/app/uploader/templates/form/input_radio_field.html
@@ -1,4 +1,4 @@
-<div class="govuk-form-group{% if field.errors %}--error{% endif %}">
+<div class="govuk-form-group{% if field.errors %} govuk-form-group--error{% endif %}">
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">{% if label %}{{ label }}{% else %}{{ field.label }}{% endif %}</h1>

--- a/app/uploader/templates/pipeline_data_verify.html
+++ b/app/uploader/templates/pipeline_data_verify.html
@@ -21,16 +21,34 @@
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                 <h1 class="govuk-fieldset__heading">{{ heading }}</h1>
             </legend>
+
             {% with field=form.proceed %}
                 {% include 'form/input_radio_field.html' %}
             {% endwith %}
+
+            {% if missing_headers %}
+              <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-warning-text govuk-!-margin-bottom-0">
+                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                  <strong class="govuk-warning-text__text">
+                    <span class="govuk-warning-text__assistive">Warning</span>
+                    The uploaded file is missing columns that were present in the last data file. Continuing will break any queries that currently rely on those columns.
+                    <br>
+                    <br>
+                    Missing column{% if missing_headers|length > 1 %}s{% endif %}: {{ missing_headers | join(', ') }}
+                  </strong>
+                </div>
+              </div></div>
+            {% endif %}
             <div class="gov-form-group govuk-!-padding-top-6">
                 <ul class="govuk-list">
                     <li>
-                        <input type="submit" value="Continue" class="govuk-button govuk-!-margin-bottom-4">
+                        <input type="submit" value="Continue{% if missing_headers %} with missing columns{% endif %}" class="govuk-button govuk-!-margin-bottom-4{% if missing_headers %} govuk-button--warning{% endif %}">
                     </li>
                 </ul>
             </div>
+
         </fieldset>
     </form>
 

--- a/app/uploader/utils.py
+++ b/app/uploader/utils.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os.path
+import re
 import time
 from io import BytesIO
 from threading import Thread
@@ -40,6 +41,18 @@ def get_s3_file_sample(url, delimiter, quotechar, number_of_lines=4):
                 raise csv.Error('Invalid CSV: duplicate header names not allowed')
             if '' in csv_headings:
                 raise csv.Error('Invalid CSV: empty header names not allowed')
+
+            invalid_headings = list(
+                filter(lambda x: not re.match("^[a-z][a-z0-9_]+$", x), csv_headings)
+            )
+            if invalid_headings:
+                joined_invalid_headings = '"' + '", "'.join(invalid_headings) + '"'
+                raise csv.Error(
+                    f"Invalid CSV: column headers must start with a letter and may only contain "
+                    f"lowercase letters, numbers, and underscores. Invalid headers: "
+                    f"{joined_invalid_headings}"
+                )
+
             csv_contents = []
             count = 0
             for row in csv_reader:

--- a/tests/uploader/test_utils.py
+++ b/tests/uploader/test_utils.py
@@ -5,7 +5,6 @@ import pandas
 import pytest
 from datatools.io.storage import S3Storage
 
-from app.constants import DEFAULT_CSV_DELIMITER, DEFAULT_CSV_QUOTECHAR
 from app.uploader.utils import get_column_types, get_s3_file_sample, upload_file
 
 
@@ -21,9 +20,9 @@ def test_save_column_types(data, expected_column_types, app_with_db):
 @pytest.mark.parametrize(
     'csv_string,delimiter,quotechar',
     (
-        ('hello,goodbye\n"1,1,1",2\n3,4\n5,6', DEFAULT_CSV_DELIMITER, DEFAULT_CSV_QUOTECHAR),
-        ('hello~goodbye\n1~2\n3~4\n5~6', '~', DEFAULT_CSV_QUOTECHAR),
-        ('hello,goodbye\n$1,1,1$,2\n3,4\n5,6', DEFAULT_CSV_DELIMITER, '$'),
+        ('hello,goodbye\n"1,1,1",2\n3,4\n5,6', ',', '"'),
+        ('hello~goodbye\n1~2\n3~4\n5~6', '~', '"'),
+        ('hello,goodbye\n$1,1,1$,2\n3,4\n5,6', ',', '$'),
     ),
 )
 @mock.patch('app.uploader.utils.open')
@@ -40,7 +39,7 @@ def test_get_s3_file_sample(mock_smart_open, csv_string, delimiter, quotechar, a
 def test_get_s3_file_sample_when_empty_column(mock_smart_open, app_with_db):
     csv_string = 'hello,goodbye\n1,2,3\n4,5,6\n7,8,9'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    result, err = get_s3_file_sample('', DEFAULT_CSV_DELIMITER, DEFAULT_CSV_QUOTECHAR)
+    result, err = get_s3_file_sample('', ',', '"')
     assert result.empty is True
     assert result.columns.to_list() == []
     assert len(result.index) == 0
@@ -51,7 +50,7 @@ def test_get_s3_file_sample_when_empty_column(mock_smart_open, app_with_db):
 def test_get_s3_file_sample_when_invalid_header(mock_smart_open, app_with_db):
     csv_string = 'hello,goodbye,\n1,2,3\n4,5,6\n7,8,9'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    result, err = get_s3_file_sample('', DEFAULT_CSV_DELIMITER, DEFAULT_CSV_QUOTECHAR)
+    result, err = get_s3_file_sample('', ',', '"')
     assert result.empty is True
     assert result.columns.to_list() == []
     assert len(result.index) == 0
@@ -62,7 +61,7 @@ def test_get_s3_file_sample_when_invalid_header(mock_smart_open, app_with_db):
 def test_get_s3_file_sample_when_duplicate_header_names(mock_smart_open, app_with_db):
     csv_string = 'hello,goodbye,goodbye\n1,2,3\n4,5,6\n7,8,9'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    result, err = get_s3_file_sample('', DEFAULT_CSV_DELIMITER, DEFAULT_CSV_QUOTECHAR)
+    result, err = get_s3_file_sample('', ',', '"')
     assert result.empty is True
     assert result.columns.to_list() == []
     assert len(result.index) == 0
@@ -73,7 +72,7 @@ def test_get_s3_file_sample_when_duplicate_header_names(mock_smart_open, app_wit
 def test_get_s3_file_sample_with_invalid_header_names(mock_smart_open, app_with_db):
     csv_string = 'spaces in header,weird :@£$% characters,Uppercase\n1,2,3\n4,5,6\n7,8,9'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    result, err = get_s3_file_sample('', DEFAULT_CSV_DELIMITER, DEFAULT_CSV_QUOTECHAR)
+    result, err = get_s3_file_sample('', ',', '"')
     assert result.empty is True
     assert result.columns.to_list() == []
     assert len(result.index) == 0

--- a/tests/uploader/test_views.py
+++ b/tests/uploader/test_views.py
@@ -8,8 +8,6 @@ from slugify import slugify
 
 from app.constants import (
     DataUploaderFileState,
-    DEFAULT_CSV_DELIMITER,
-    DEFAULT_CSV_QUOTECHAR,
     NO,
     YES,
 )
@@ -267,7 +265,7 @@ def test_get_data_upload_view(is_authenticated, app_with_db, captured_templates)
 def test_get_data_verify_view(mock_smart_open, is_authenticated, app_with_db, captured_templates):
     csv_string = 'hello,goodbye\n1,2\n3,4'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    data_file = PipelineDataFileFactory()
+    data_file = PipelineDataFileFactory(pipeline__delimiter=',')
     client = get_client(app_with_db)
     url = url_for(
         'uploader_views.pipeline_data_verify', slug=data_file.pipeline.slug, file_id=data_file.id
@@ -342,7 +340,7 @@ def test_submit_data_verify_proceed_yes(
     mock_process_pipeline_data_file.return_value = mock_thread
     csv_string = 'hello,goodbye\n1,2\n3,4'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    data_file = PipelineDataFileFactory()
+    data_file = PipelineDataFileFactory(pipeline__delimiter=',')
     client = get_client(app_with_db)
     url = url_for(
         'uploader_views.pipeline_data_verify', slug=data_file.pipeline.slug, file_id=data_file.id
@@ -371,7 +369,7 @@ def test_submit_data_upload_view(
 ):
     csv_string = 'hello,goodbye\n1,2\n3,4'
     mock_smart_open.return_value = io.StringIO(csv_string)
-    pipeline = PipelineFactory(delimiter=DEFAULT_CSV_DELIMITER, quote=DEFAULT_CSV_QUOTECHAR)
+    pipeline = PipelineFactory(delimiter=",", quote='"')
     client = get_client(app_with_db)
     url = url_for('uploader_views.pipeline_data_upload', slug=pipeline.slug)
     form_data = {'csv_file': (io.BytesIO(bytes(csv_string, encoding='utf-8')), 'test.csv')}
@@ -401,7 +399,7 @@ def test_submit_data_upload_view_additional_dataset(
 
     mock_smart_open.return_value = io.StringIO(file_1_csv_string)
     mock_upload_file.return_value = 'fakefile_1.csv'
-    pipeline = PipelineFactory(delimiter=DEFAULT_CSV_DELIMITER, quote=DEFAULT_CSV_QUOTECHAR)
+    pipeline = PipelineFactory(delimiter=",", quote='"')
     client = get_client(app_with_db)
     url = url_for('uploader_views.pipeline_data_upload', slug=pipeline.slug)
 
@@ -485,7 +483,7 @@ def test_get_restore_version_view(
     # The view first gets the s3 sample of the latest version and then the version to restore
     mock_smart_open.side_effect = [io.StringIO(csv_string_1), io.StringIO(csv_string_2)]
 
-    pipeline = PipelineFactory()
+    pipeline = PipelineFactory(delimiter=',')
     # Latest version
     PipelineDataFileFactory(
         pipeline=pipeline,
@@ -567,7 +565,7 @@ def test_submit_restore_version_proceed(
     # The view first gets the s3 sample of the latest version and then the version to restore
     mock_smart_open.side_effect = [io.StringIO(csv_string), io.StringIO(csv_string)]
 
-    pipeline = PipelineFactory()
+    pipeline = PipelineFactory(delimiter=',')
     # Latest version
     PipelineDataFileFactory(
         pipeline=pipeline,


### PR DESCRIPTION
We want to have some basic QA on uploaded CSVs, which in this case means
making sure that they're only alphanumeric with underscores - no
symbols, spaces, etc.

We also want to call attention to uploaded data that is backwards-incompatible with previous uploads, so that users have the opportunity to make informed decisions about whether or not their upload might break existing queries.

## Show it
<img width="1073" alt="Screen Shot 2020-08-06 at 15 07 11" src="https://user-images.githubusercontent.com/2920760/89541686-992cd400-d7f6-11ea-93af-0ecca94f9aec.png">

<img width="1085" alt="Screen Shot 2020-08-06 at 15 18 42" src="https://user-images.githubusercontent.com/2920760/89542867-245a9980-d7f8-11ea-80a7-b980a1089a30.png">

