### PR TITLE
Return to upload progress

### DIFF
--- a/app/uploader/templates/pipeline_data_upload.html
+++ b/app/uploader/templates/pipeline_data_upload.html
@@ -14,10 +14,18 @@
         </tr>
     </thead>
     <tbody class="govuk-table__body">
-    {% for data_file in pipeline.data_files if data_file.state in ('completed', 'uploaded') %}
+    {% for data_file in pipeline.data_files if data_file.state in ('processing_dss', 'processing_dataflow', 'completed', 'uploaded') %}
         <tr class="govuk-table__row">
             <td class="govuk-table__cell">{{ data_file.uploaded_at }}</td>
-            <td class="govuk-table__cell">{% if data_file.processed_at %} {{ data_file.processed_at }} {% elif data_file.state == 'uploaded' %}<a href="{{ url_for('uploader_views.pipeline_data_verify', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Process</a>{% endif %}</td>
+
+            {% if data_file.processed_at %}
+              <td class="govuk-table__cell">{{ data_file.processed_at }}</td>
+            {% elif data_file.state == 'uploaded' %}
+              <td class="govuk-table__cell"><a href="{{ url_for('uploader_views.pipeline_data_verify', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Process</a></td>
+            {% elif data_file.state in ('processing_dss', 'processing_dataflow') %}
+              <td class="govuk-table__cell"><a href="{{ url_for('uploader_views.pipeline_data_uploaded', slug=data_file.pipeline.slug, file_id=data_file.id) }}">View progress</a></td>
+            {% endif %}
+
             <td class="govuk-table__cell">{% if data_file.processed_at %} {% if data_file.id == data_file.pipeline.latest_version.id %}Latest{% else %}<a href="{{ url_for('uploader_views.pipeline_restore_version', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Restore</a>{% endif %}{% endif %}</td>
         </tr>
     {% endfor %}

--- a/app/uploader/templates/pipeline_data_upload.html
+++ b/app/uploader/templates/pipeline_data_upload.html
@@ -19,14 +19,20 @@
             <td class="govuk-table__cell">{{ data_file.uploaded_at }}</td>
 
             {% if data_file.processed_at %}
-              <td class="govuk-table__cell">{{ data_file.processed_at }}</td>
+              <td class="govuk-table__cell">
+                {{ data_file.processed_at }}
+              </td>
             {% elif data_file.state == 'uploaded' %}
-              <td class="govuk-table__cell"><a href="{{ url_for('uploader_views.pipeline_data_verify', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Process</a></td>
+              <td class="govuk-table__cell">
+                <a class="govuk-link" href="{{ url_for('uploader_views.pipeline_data_verify', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Process</a>
+              </td>
             {% elif data_file.state in ('processing_dss', 'processing_dataflow') %}
-              <td class="govuk-table__cell"><a href="{{ url_for('uploader_views.pipeline_data_uploaded', slug=data_file.pipeline.slug, file_id=data_file.id) }}">View progress</a></td>
+              <td class="govuk-table__cell">
+                <a class="govuk-link" href="{{ url_for('uploader_views.pipeline_data_uploaded', slug=data_file.pipeline.slug, file_id=data_file.id) }}">View progress</a>
+              </td>
             {% endif %}
 
-            <td class="govuk-table__cell">{% if data_file.processed_at %} {% if data_file.id == data_file.pipeline.latest_version.id %}Latest{% else %}<a href="{{ url_for('uploader_views.pipeline_restore_version', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Restore</a>{% endif %}{% endif %}</td>
+            <td class="govuk-table__cell">{% if data_file.processed_at %} {% if data_file.id == data_file.pipeline.latest_version.id %}Latest{% else %}<a class="govuk-link" href="{{ url_for('uploader_views.pipeline_restore_version', slug=data_file.pipeline.slug, file_id=data_file.id)}}">Restore</a>{% endif %}{% endif %}</td>
         </tr>
     {% endfor %}
     </tbody>

--- a/app/uploader/templates/pipeline_data_uploaded.html
+++ b/app/uploader/templates/pipeline_data_uploaded.html
@@ -59,6 +59,7 @@ window.onload = function() {
     const interval = setInterval(function() {
        check_progress('{{ file_id }}', interval);
      }, interval_time);
+     check_progress('{{ file_id }}', interval);
 }
 
 </script>

--- a/app/uploader/views.py
+++ b/app/uploader/views.py
@@ -151,6 +151,9 @@ def pipeline_data_verify(slug, file_id):
         pipeline_data_file.state = DataUploaderFileState.VERIFIED.value
         pipeline_data_file.save()
 
+        thread = process_pipeline_data_file(pipeline_data_file)
+        thread.start()
+
         return redirect(
             url_for(
                 'uploader_views.pipeline_data_uploaded',
@@ -200,6 +203,9 @@ def pipeline_restore_version(slug, file_id):
         data_file_to_restore.state = DataUploaderFileState.VERIFIED.value
         data_file_to_restore.save()
 
+        thread = process_pipeline_data_file(data_file_to_restore)
+        thread.start()
+
         return redirect(
             url_for(
                 'uploader_views.pipeline_data_uploaded',
@@ -237,9 +243,7 @@ def pipeline_data_uploaded(slug, file_id):
         raise BadRequest("Invalid schema for this pipeline.")
     data_workspace_schema_name = schema_parts[0]
     data_workspace_table_name = schema_parts[1]
-    thread = process_pipeline_data_file(pipeline_data_file)
     file_id = pipeline_data_file.id
-    thread.start()
     return render_uploader_template(
         'pipeline_data_uploaded.html',
         pipeline=pipeline,

--- a/tests/uploader/test_views.py
+++ b/tests/uploader/test_views.py
@@ -495,6 +495,10 @@ def test_get_data_upload_view_existing_versions(is_authenticated, app_with_db, c
         state=DataUploaderFileState.COMPLETED.value,
         processed_at=datetime.datetime(2020, 6, 1),
     )
+    # Version that is in the middle of processing
+    PipelineDataFileFactory(
+        pipeline=pipeline, state=DataUploaderFileState.PROCESSING_DATAFLOW.value, processed_at=None
+    )
     # Version that is yet to be processed
     PipelineDataFileFactory(
         pipeline=pipeline, state=DataUploaderFileState.UPLOADED.value, processed_at=None
@@ -509,7 +513,8 @@ def test_get_data_upload_view_existing_versions(is_authenticated, app_with_db, c
 
     assert 'Latest' in html  # data_file_1
     assert 'Restore' in html  # data_file_2
-    assert 'Process' in html  # data_file_3
+    assert 'View progress' in html  # data_file_3
+    assert 'Process' in html  # data_file_4
 
 
 @mock.patch('data_engineering.common.sso.token.is_authenticated', return_value=True)


### PR DESCRIPTION
This patch adds a link back to the 'data processing progress' page from
the pipeline overview page. Previously it wasn't possible to get back to
this page through the UI (though you could hack the URL). Reloading the
'progress' page would also end up spawning a new processor thread,
meaning that the same data file could be processed multiple times. This
moves the spawning step to the validated POST, and leaves the 'GET
progress' view as just returning updates on how the processor is doing.