### PR TITLE
fix: set USE_DOTENV variable in docker-compose

### DIFF
--- a/app/config/docker.yml
+++ b/app/config/docker.yml
@@ -1,2 +1,0 @@
-app:
-  database_url: postgresql://postgres:postgres@dss_postgres/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   dss_web:
     build: .
     environment:
-      - DOCKER=1
+      - USE_DOTENV=1
     env_file:
       - ${ENV_FILE:-.env}
     ports:

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ flask-wtf==0.14.3
 flask==1.1.1
 freezegun==0.3.15
 fuzzywuzzy==0.18.0
-git+https://github.com/uktrade/data-engineering-common.git@v1.2.3
+git+https://github.com/uktrade/data-engineering-common.git@v1.2.4
 git+https://github.com/uktrade/dt08-data-tools.git
 gunicorn[gevent]==20.*
 json-log-formatter==0.3.0


### PR DESCRIPTION
This allows overriding all env vars by using a .env file when running the app locally via docker compose. This commit also deleted the docker.yml config file as any local configuration should be done via the .env file.