### PR TITLE
feat: use shared data infrastructure dev network

### DIFF
--- a/.envs/docker.env
+++ b/.envs/docker.env
@@ -1,6 +1,13 @@
 COMPOSE_PROJECT_NAME=data
+
+DSS_DATABASE_URL=postgresql://postgres:postgres@dss_postgres:5432/postgres
 POSTGRES_PASSWORD=postgres
+
 DOCKER=1
 AUTHBROKER_URL=https://sso.trade.gov.uk/
 AUTHBROKER_CLIENT_ID=123
 AUTHBROKER_CLIENT_SECRET=456
+
+DATAFLOW_BASE_URL=http://data-flow:8080
+DATAFLOW_HAWK_ID=data-store-service-id
+DATAFLOW_HAWK_KEY=data-store-service-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,8 @@ services:
     restart: always
     ports:
       - "6375:6379"
+
+networks:
+  default:
+    name: data-infrastructure-shared-network
+


### PR DESCRIPTION
When running data-store-service through docker-compose, make it use a
shared Data Infrastructure network so that, by default, all of our apps
can theoretically talk to each other. This may be useful e.g. when
running/testing uploads locally, as they rely on data-flow.