### PR TITLE
feat: clean up old pipeline processing tasks

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -1,9 +1,12 @@
 import os
 
 import sentry_sdk
+from apscheduler.schedulers.background import BackgroundScheduler
 from data_engineering.common.sso.register import register_sso_component
 from flask_migrate import Migrate
 from sentry_sdk.integrations.flask import FlaskIntegration
+
+from app.uploader.utils import mark_old_processing_data_files_as_failed
 
 config_location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__), 'config'))
 
@@ -22,6 +25,12 @@ def register_app_components(flask_app):
 
     if os.environ.get('NO_BROWSER_CACHE'):
         no_browser_cache(flask_app)
+
+    sched = BackgroundScheduler(daemon=True)
+    sched.add_job(
+        mark_old_processing_data_files_as_failed, 'interval', kwargs=dict(app=flask_app), minutes=60
+    )
+    sched.start()
 
     return flask_app
 

--- a/app/db/models/internal.py
+++ b/app/db/models/internal.py
@@ -136,6 +136,7 @@ class PipelineDataFile(BaseModel):
     state = _col(_text)
     error_message = _col(_text)
     uploaded_at = _col(_dt, default=lambda: datetime.datetime.utcnow())
+    started_processing_at = _col(_dt)
     processed_at = _col(_dt)
     column_types = _col(_array(_text))
     delimiter = _col(_text, nullable=False, server_default=DEFAULT_CSV_DELIMITER)

--- a/migrations/versions/20201019_2237_ac7dbd72d46e_.py
+++ b/migrations/versions/20201019_2237_ac7dbd72d46e_.py
@@ -1,0 +1,31 @@
+"""add column to pipeline_data_file to track when processing began
+
+Revision ID: ac7dbd72d46e
+Revises: 2258ff389578
+Create Date: 2020-10-19 22:37:52.754276
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql.schema import quoted_name  # noqa: F401
+
+revision = 'ac7dbd72d46e'
+down_revision = '2258ff389578'
+
+
+def upgrade():
+    schema_upgrades()
+
+
+def downgrade():
+    schema_downgrades()
+
+
+def schema_upgrades():
+    op.add_column(
+        'pipeline_data_file', sa.Column('started_processing_at', sa.DateTime(), nullable=True)
+    )
+
+
+def schema_downgrades():
+    op.drop_column('pipeline_data_file', 'started_processing_at')

--- a/tests/uploader/test_utils.py
+++ b/tests/uploader/test_utils.py
@@ -1,8 +1,12 @@
+from datetime import datetime, timedelta
 from unittest import mock
 
 from datatools.io.storage import S3Storage
 
-from app.uploader.utils import upload_file
+from app.constants import DataUploaderFileState
+from app.db.models.internal import PipelineDataFile
+from app.uploader.utils import mark_old_processing_data_files_as_failed, upload_file
+from tests.fixtures.factories import PipelineDataFileFactory
 
 
 @mock.patch('app.uploader.utils.StorageFactory.create')
@@ -12,3 +16,23 @@ def test_upload_file(mock_create_storage, app_with_db):
         upload_file('test.csv', 'bla')
     assert mock_create_storage.called is True
     assert mock_write_file.called is True
+
+
+def test_mark_old_processing_data_files_as_failed(app_with_db):
+    recent_uuid = 'ed67ecea-9567-4f87-a5b5-eb517d84ce6c'
+    PipelineDataFileFactory(
+        id=recent_uuid,
+        state=DataUploaderFileState.VERIFIED.value,
+        started_processing_at=datetime.now() - timedelta(hours=1),
+    )
+    old_uuid = '7849ab8c-96e4-40ff-afc7-40ae1decd6b2'
+    PipelineDataFileFactory(
+        id=old_uuid,
+        state=DataUploaderFileState.VERIFIED.value,
+        started_processing_at=datetime.now() - timedelta(days=2),
+    )
+
+    mark_old_processing_data_files_as_failed(app_with_db)
+
+    assert PipelineDataFile.query.get(recent_uuid).state == DataUploaderFileState.VERIFIED.value
+    assert PipelineDataFile.query.get(old_uuid).state == DataUploaderFileState.FAILED.value


### PR DESCRIPTION
A rudimentary implementation of a cleanup job that ensures pipelines
don't get stuck in "processing" step forever. This can happen right now
if the app instance dies while a data file is being processed (either by
data-store-service or data-flow), because the task is simply kicked off
as a background thread on the web worker and there is no retry/recovery
mechanism.

In the future we'll want to move to some more robust background job
handler (e.g. celery), but for now this service is only used within our
team and so that level of robustness is not required.