### PR TITLE
change DSVToTablePipeline to incremental pipeline

### DIFF
--- a/app/etl/pipeline_type/dsv_to_table.py
+++ b/app/etl/pipeline_type/dsv_to_table.py
@@ -1,10 +1,10 @@
 from io import BytesIO
 
-from app.etl.pipeline_type.snapshot_data import L0SnapshotDataPipeline
+from app.etl.pipeline_type.incremental_data import L0IncrementalDataPipeline
 from app.utils import trigger_dataflow_dag
 
 
-class DSVToTablePipeline(L0SnapshotDataPipeline):
+class DSVToTablePipeline(L0IncrementalDataPipeline):
     def __init__(
         self, dbi, organisation, dataset, data_column_types, separator=',', quote='"', **kwargs
     ):
@@ -23,7 +23,7 @@ class DSVToTablePipeline(L0SnapshotDataPipeline):
             has_header=True,
             sep=self.separator,
             quote=self.quote,
-            columns=None,
+            columns=[c for c, _ in self._l0_data_column_types],
         )
 
     def _format_column_names(self, column_types):

--- a/tests/etl/test_dsv_to_table.py
+++ b/tests/etl/test_dsv_to_table.py
@@ -53,6 +53,65 @@ class TestDSVToTablePipeline:
         ]
         assert rows_equal_table(app_with_db.dbi, expected_rows, pipeline._l0_table, pipeline)
 
+    def test_pipeline_with_comtrade_csv_with_duplicate_rows(self, app_with_db):
+        pipeline = DSVToTablePipeline(
+            app_with_db.dbi,
+            organisation='comtrade',
+            dataset='country_code_and_iso',
+            data_column_types=[
+                ('ctyCode', 'int'),
+                ('cty Name English', 'text'),
+                ('cty Fullname English', 'text'),
+                ('Cty Abbreviation', 'text'),
+                ('Cty Comments', 'text'),
+                ('ISO2-digit Alpha', 'text'),
+                ('ISO3-digit Alpha', 'text'),
+                ('Start Valid Year', 'text'),
+                ('End Valid Year', 'text'),
+            ],
+        )
+        fi = FileInfo.from_path('tests/fixtures/generic_dsv/country_list_dups.csv')
+        pipeline.process(fi)
+
+        expected_rows = [
+            (0, 'World', 'World', 'World', 'World', 'WL', 'WLD', '1962', '2061'),
+            (4, 'Afghanistan', 'Afghanistan', 'Afghanistan', None, 'AF', 'AFG', '1962', '2061'),
+            (
+                899,
+                'Areas, nes',
+                'Areas, not elsewhere specified',
+                'Areas, nes',
+                None,
+                None,
+                None,
+                '1962',
+                '2061',
+            ),
+            (
+                918,
+                'European Union',
+                'European Union',
+                'European Union',
+                None,
+                'EU',
+                'EUR',
+                None,
+                None,
+            ),
+            (
+                918,
+                'European Union',
+                'European Union',
+                'European Union',
+                None,
+                'EU',
+                'EUR',
+                None,
+                None,
+            ),
+        ]
+        assert rows_equal_table(app_with_db.dbi, expected_rows, pipeline._l0_table, pipeline)
+
     def test_pipeline_with_ons_csv(self, app_with_db):
         pipeline = DSVToTablePipeline(
             app_with_db.dbi,

--- a/tests/fixtures/generic_dsv/country_list_dups.csv
+++ b/tests/fixtures/generic_dsv/country_list_dups.csv
@@ -3,3 +3,4 @@
 4,Afghanistan,Afghanistan,Afghanistan,,AF,AFG,1962,2061
 899,"Areas, nes","Areas, not elsewhere specified","Areas, nes",,,,1962,2061
 918,European Union,European Union,European Union,,EU,EUR,,
+918,European Union,European Union,European Union,,EU,EUR,,


### PR DESCRIPTION
`Data uploader` uses a snapshot pipeline that only saves unique rows. This PR changes the `DSVToTablePipeline` to incremental pipeline so as to save duplicate rows as wel.