### PR TITLE
Move scheduler to separate CF process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,13 @@ compile_assets:
 run_server: compile_assets
 	exec gunicorn 'data_engineering.common.application:get_or_create()' -b 0.0.0.0:${PORT} --config 'app/config/gunicorn_config.py'
 
-
 .PHONY: run_dev_server
 run_dev_server:
 	USE_DOTENV=1 FLASK_DEBUG=1 FLASK_APP='data_engineering.common.application:get_or_create()' flask run --host 0.0.0.0 --port ${PORT}
+
+.PHONY: run_scheduler
+run_scheduler:
+	USE_DOTENV=1 FLASK_APP='data_engineering.common.application:get_or_create()' flask scheduler start
 
 .PHONY: run_tests
 run_tests:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: make run_server
+scheduler: make run_scheduler

--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ An s3 bucket can be created using the Cloud Foundry command line tools, e.g.
 
 Reference: 
 https://docs.cloud.service.gov.uk/deploying_services/s3/#connect-to-an-s3-bucket-from-your-app
+
+## Running database migrations
+
+Database migrations currently are not run automatically on deployment because there is concern that they do not work well for the pipeline tables. Until this is resolved, migrations need to be run manually and consideration needs to be given to how this will affect deploying structural database changes.
+
+1) Deploy the migrations to the relevant environment.
+2) `cf v3-ssh data-store-service-<env>` - SSH into the instance
+3) `/tmp/lifecycle/shell` - active the app environment
+4) `./manage.py db upgrade` - run the migrations

--- a/app/application.py
+++ b/app/application.py
@@ -1,12 +1,9 @@
 import os
 
 import sentry_sdk
-from apscheduler.schedulers.background import BackgroundScheduler
 from data_engineering.common.sso.register import register_sso_component
 from flask_migrate import Migrate
 from sentry_sdk.integrations.flask import FlaskIntegration
-
-from app.uploader.utils import mark_old_processing_data_files_as_failed
 
 config_location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__), 'config'))
 
@@ -25,12 +22,6 @@ def register_app_components(flask_app):
 
     if os.environ.get('NO_BROWSER_CACHE'):
         no_browser_cache(flask_app)
-
-    sched = BackgroundScheduler(daemon=True)
-    sched.add_job(
-        mark_old_processing_data_files_as_failed, 'interval', kwargs=dict(app=flask_app), minutes=60
-    )
-    sched.start()
 
     return flask_app
 

--- a/app/commands/__init__.py
+++ b/app/commands/__init__.py
@@ -1,5 +1,6 @@
-from app.commands.dev import cmd_group
+from app.commands.dev import cmd_group as dev_cmd_group
+from app.commands.scheduler import cmd_group as scheduler_cmd_group
 
 
 def get_command_groups():
-    return [cmd_group]
+    return [dev_cmd_group, scheduler_cmd_group]

--- a/app/commands/scheduler.py
+++ b/app/commands/scheduler.py
@@ -1,0 +1,24 @@
+import click
+from apscheduler.schedulers.background import BlockingScheduler
+from flask import current_app
+from flask.cli import AppGroup, with_appcontext
+
+from app.uploader.utils import mark_old_processing_data_files_as_failed
+
+
+@click.command('start')
+@with_appcontext
+def start_scheduler():
+    """Start the job scheduler"""
+    sched = BlockingScheduler(daemon=True)
+    sched.add_job(
+        mark_old_processing_data_files_as_failed,
+        'interval',
+        kwargs=dict(app=current_app),
+        minutes=60,
+    )
+    sched.start()
+
+
+cmd_group = AppGroup('scheduler', help='Commands to manage the task scheduler')
+cmd_group.add_command(start_scheduler)


### PR DESCRIPTION
Gunicorn launches ~8 workers in our deployed environment now, and with
the current setup each of those will startup a background scheduler with
a copy of the tasks to run.

Let's use a separate CF process to run a single scheduler instance.
