### PR TITLE
fix: clean up all pipelines

### DIFF
--- a/app/uploader/utils.py
+++ b/app/uploader/utils.py
@@ -158,8 +158,8 @@ def mark_old_processing_data_files_as_failed(app):
             )
         ):
             if (
-                pipeline_data_file.started_processing_at is not None
-                and pipeline_data_file.started_processing_at <= one_day_ago
+                pipeline_data_file.started_processing_at is None
+                or pipeline_data_file.started_processing_at <= one_day_ago
             ):
                 logging.info(
                     "Marking %s as failed (didn't complete within 24 hours)", pipeline_data_file


### PR DESCRIPTION
Now that this cleanup code has been out for a while, we can broaden the
conditions to check all historical pipelines as old ones without a
started_processing_at date will all be more than 24 hours old.