### PR TITLE
feature: use webdriver-manager to select  the correct chrome driver

### DIFF
--- a/app/config/defaults.yml
+++ b/app/config/defaults.yml
@@ -4,7 +4,6 @@ app:
   secret_key: $ENV{DSS_APP_SECRET_KEY, random_string_dss}
   database_url: $ENV{DSS_DATABASE_URL, postgresql://postgres@dss_postgres/postgres}
   pagination_size: $ENV{DSS_PAGINATION_SIZE, 1000}
-  chrome_driver_path: $ENV{DSS_CHROME_DRIVER_PATH, ./drivers/chromedriver-85-linux64}
   chrome_binary_location: $ENV{DSS_CHROME_BINARY_LOCATION, /home/vcap/deps/0/lib/chromium-browser/chromium-browser}
 sso:
   base_url: $ENV{AUTHBROKER_URL, https://sso.trade.gov.uk}

--- a/app/downloader/inspector.py
+++ b/app/downloader/inspector.py
@@ -13,6 +13,7 @@ from selenium.common.exceptions import (
     TimeoutException,
 )
 from selenium.webdriver.support.wait import WebDriverWait
+from webdriver_manager.chrome import ChromeDriverManager
 
 DataUrl = namedtuple('DataUrl', 'url date')
 
@@ -95,9 +96,9 @@ class SeleniumOnlineInspector(OnlineInspector):
             NoSuchElementException,
             StaleElementReferenceException,
         )
+
         driver = webdriver.Chrome(
-            executable_path=flask_app.config['app']['chrome_driver_path'],
-            chrome_options=chrome_options,
+            executable_path=ChromeDriverManager().install(), chrome_options=chrome_options
         )
         driver.get(self.url)
 

--- a/requirements.in
+++ b/requirements.in
@@ -41,4 +41,5 @@ tableschema==1.19.3
 tabulator==1.52.3
 toolz==0.10.0
 watchdog==0.10.3
+webdriver-manager==3.2.2
 werkzeug==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,10 @@ certifi==2019.11.28       # via data-engineering-common, requests, sentry-sdk
 chardet==3.0.4            # via requests, tabulator
 click==7.0                # via black, flask, flask-shell-ipython, pip-tools, tableschema, tabulator
 codecov==2.1.9            # via -r requirements.in
+colorama==0.4.4           # via crayons
+configparser==5.0.1       # via webdriver-manager
 coverage==5.0.3           # via codecov, pytest-cov
+crayons==0.4.0            # via webdriver-manager
 cymem==2.0.3              # via preshed, spacy, thinc
 git+https://github.com/uktrade/data-engineering-common.git@v1.2.4  # via -r requirements.in
 decorator==4.4.1          # via ipython, traitlets
@@ -69,7 +72,7 @@ jsonschema==3.2.0         # via tableschema
 linear-tsv==1.1.0         # via tabulator
 lxml==3.8.0               # via -r requirements.in
 mako==1.1.3               # via alembic
-markupsafe==1.1.1         # via jinja2, mako, wtforms
+markupsafe==1.1.1         # via jinja2, mako
 mccabe==0.6.1             # via flake8
 mohawk==1.1.0             # via -r requirements.in, data-engineering-common
 more-itertools==8.2.0     # via pytest
@@ -111,7 +114,7 @@ pyyaml==5.3.1             # via -r requirements.in, data-engineering-common
 redis==3.5.3              # via -r requirements.in, data-engineering-common
 regex==2020.10.11         # via black
 requests-oauthlib==1.1.0  # via -r requirements.in, data-engineering-common, flask-oauthlib
-requests==2.22.0          # via codecov, data-engineering-common, requests-oauthlib, spacy, tableschema, tabulator
+requests==2.22.0          # via codecov, data-engineering-common, requests-oauthlib, spacy, tableschema, tabulator, webdriver-manager
 rfc3986==1.4.0            # via tableschema
 s3transfer==0.3.2         # via boto3
 selenium==3.141.0         # via -r requirements.in
@@ -139,6 +142,7 @@ urllib3==1.25.8           # via botocore, requests, selenium, sentry-sdk
 wasabi==0.6.0             # via spacy, thinc
 watchdog==0.10.3          # via -r requirements.in
 wcwidth==0.2.5            # via prompt-toolkit
+webdriver-manager==3.2.2  # via -r requirements.in
 werkzeug==0.16.1          # via -r requirements.in, data-engineering-common, flask
 wtforms==2.2.1            # via flask-wtf
 xlrd==1.2.0               # via tabulator


### PR DESCRIPTION
Downloading the chromedriver binary and configuring the path is no longer the recommended way to set it up. This can be done automatically using webdriver-manager. See https://stackoverflow.com/questions/29858752/error-message-chromedriver-executable-needs-to-be-available-in-the-path/52878725#52878725.

This should resolve the following sentry error we have started seeing recently.

https://sentry.ci.uktrade.digital/dit/data-store-service/issues/33921/?referrer=slack