### PR TITLE
fix: ONS postcode pipeline by correcting path to Chromium

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: make run_server
-scheduler: make run_scheduler
+web: ./scripts/fix_chromium_path.sh && make run_server
+scheduler: ./scripts/fix_chromium_path.sh && make run_scheduler

--- a/app/downloader/inspector.py
+++ b/app/downloader/inspector.py
@@ -14,6 +14,7 @@ from selenium.common.exceptions import (
 )
 from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.utils import ChromeType
 
 DataUrl = namedtuple('DataUrl', 'url date')
 
@@ -98,7 +99,8 @@ class SeleniumOnlineInspector(OnlineInspector):
         )
 
         driver = webdriver.Chrome(
-            executable_path=ChromeDriverManager().install(), chrome_options=chrome_options
+            executable_path=ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install(),
+            chrome_options=chrome_options,
         )
         driver.get(self.url)
 

--- a/scripts/fix_chromium_path.sh
+++ b/scripts/fix_chromium_path.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# For some reason on CF the symbolic link to chromium-browser in the path is setup incorrectly
+
+rm /home/vcap/deps/0/bin/chromium-browser
+ln -s /home/vcap/deps/0/lib/chromium-browser/chromium-browser /home/vcap/deps/0/bin/chromium-browser


### PR DESCRIPTION
... and telling webdriver-manager to use Chromium, rather than the default which is Google Chrome.

Suspect this was broken since https://github.com/uktrade/data-store-service/pull/262