### PR TITLE
fix: add prompt to run migrations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
       when {
           expression {
               milestone label: "release-staging"
-              input message: 'Deploy to staging?'
+              input message: 'Deploy to staging? Note: migrations are not automated. Have you run any required migrations?'
               return true
           }
           beforeAgent true
@@ -33,7 +33,7 @@ pipeline {
       when {
           expression {
               milestone label: "release-prod"
-              input message: 'Deploy to prod?'
+              input message: 'Deploy to production? Note: migrations are not automated. Have you run any required migrations?'
               return true
           }
           beforeAgent true


### PR DESCRIPTION
Data Store Service is not set up with automatic migrations currently,
because of some historical fears about some tables not being OK to
migrate automatically.

Until we can investigate that, let's at least put a reminder into the
pipeline so that people know it needs to be done manually/with thought.