### PR TITLE
feat: alow for configurable sample size

### DIFF
--- a/app/config/defaults.yml
+++ b/app/config/defaults.yml
@@ -5,6 +5,7 @@ app:
   database_url: $ENV{DSS_DATABASE_URL, postgresql://postgres@dss_postgres/postgres}
   pagination_size: $ENV{DSS_PAGINATION_SIZE, 1000}
   chrome_binary_location: $ENV{DSS_CHROME_BINARY_LOCATION, /home/vcap/deps/0/lib/chromium-browser/chromium-browser}
+  csv_sample_infer_lines: $ENV{CSV_SAMPLE_INFER_LINES, 100000}
 sso:
   base_url: $ENV{AUTHBROKER_URL, https://sso.trade.gov.uk}
   profile_path: $ENV{ACCESS_TOKEN_PATH, /api/v1/user/me/}

--- a/app/uploader/csv_parser.py
+++ b/app/uploader/csv_parser.py
@@ -45,13 +45,7 @@ class CSVParser:
 
     @classmethod
     def get_csv_sample(
-        cls,
-        url,
-        delimiter=",",
-        quotechar='"',
-        number_of_lines_sample=4,
-        number_of_lines_infer=100000,
-        encoding=None,
+        cls, url, delimiter=",", quotechar='"', number_of_lines_sample=4, encoding=None
     ):
         bucket = app.config['s3']['bucket_url']
         full_url = os.path.join(bucket, url)
@@ -69,7 +63,7 @@ class CSVParser:
                 post_parse=[cls.check_and_clean_up_row],
             ) as csv_file:
                 sample = csv_file.sample
-                contents = csv_file.read(limit=number_of_lines_infer)
+                contents = csv_file.read(limit=app.config['app']['csv_sample_infer_lines'])
                 headers = csv_file.headers
 
             if not headers:


### PR DESCRIPTION
Set the number of lines read in to infer data types in the environment (with fall back to the original, 100,000)

The reasoning for this is that the world bank data import is currently getting killed when attempting to read in 100k lines to infer data types.