### PR TITLE
feat: add pipeline failure page

### DIFF
--- a/app/config/local_testing.yml
+++ b/app/config/local_testing.yml
@@ -3,3 +3,4 @@ flask:
 app:
   hawk_enabled: True
   database_url: $ENV{DSS_DATABASE_URL, postgresql://postgres:postgres@dss_postgres/postgres}
+

--- a/app/uploader/templates/pipeline_data_upload_failed.html
+++ b/app/uploader/templates/pipeline_data_upload_failed.html
@@ -1,0 +1,18 @@
+{% extends 'data_store_service/base.html' %}
+{% block title %}Sorry, your upload failed - Data Store Service{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Sorry, your upload failed</h1>
+      <p class="govuk-body">
+      Unfortunately, there has been a problem processing your file and the pipeline for
+      <strong>"{{ data_workspace_schema_name }}"."{{ data_workspace_table_name }}"</strong>
+      has failed. Please try again later.
+      </p>
+      <a class="govuk-button govuk-!-margin-top-6" href="{{ url_for('uploader_views.pipeline_data_upload', slug=pipeline.slug) }}">
+        Try again
+      </a>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/uploader/templates/pipeline_data_uploaded.html
+++ b/app/uploader/templates/pipeline_data_uploaded.html
@@ -13,13 +13,10 @@
 var count = 0
 var interval_time = 5000
 var timeout = 2700000
+var failed_url = "{{ url_for('uploader_views.pipeline_data_upload_failed', slug=pipeline.slug, file_id=file_id) }}";
 function check_progress(file_id, interval) {
     if (count > timeout/interval_time) {  // stop polling after 45 mins
-        clearInterval(interval);
-        document.getElementById("pipeline_progress").value = 100;
-        document.getElementById("pipeline_progress_label").innerHTML = 'Failed';
-        document.getElementById("pipeline_info").innerHTML = "Didn't get a successful completion \
-         update from Data Flow in time";
+        window.location.replace(failed_url);
         return
     }
     var xmlhttp = new XMLHttpRequest();
@@ -28,25 +25,24 @@ function check_progress(file_id, interval) {
         if (xmlhttp.readyState == XMLHttpRequest.DONE) {   // XMLHttpRequest.DONE == 4
            if (xmlhttp.status == 200) {
                var response = JSON.parse(xmlhttp.responseText);
-               document.getElementById("pipeline_progress").value = response.progress;
-               document.getElementById("pipeline_info").innerHTML = response.info;
                if (response.progress == 100) {
                     clearInterval(interval);
                     if (response.state == 'completed') {
                         document.getElementById("pipeline_progress_label").innerHTML = 'Completed';
+                        document.getElementById("pipeline_progress").value = response.progress;
                         document.getElementById("pipeline_info").innerHTML = 'The data will \
                          be available in Data Workspace in table "{{ data_workspace_table_name }}" \
                          under schema "{{ data_workspace_schema_name }}"';
                     } else if (response.state == 'failed') {
-                        document.getElementById("pipeline_progress_label").innerHTML = 'Failed';
-                        document.getElementById("pipeline_info").innerHTML = response.info;
+                        window.location.replace(failed_url);
                     }
+               } else {
+                   document.getElementById("pipeline_progress").value = response.progress;
+                   document.getElementById("pipeline_info").innerHTML = response.info;
                }
            }
            else {
-               document.getElementById("pipeline_progress_label").innerHTML = 'Failed';
-               document.getElementById("pipeline_info").innerHTML = 'Could not retrieve progress';
-               clearInterval(interval);
+               window.location.replace(failed_url);
            }
         }
     };

--- a/app/uploader/views.py
+++ b/app/uploader/views.py
@@ -251,6 +251,12 @@ def pipeline_data_uploaded(slug, file_id):
     data_workspace_schema_name = schema_parts[0]
     data_workspace_table_name = schema_parts[1]
     file_id = pipeline_data_file.id
+
+    if pipeline_data_file.state == DataUploaderFileState.FAILED.value:
+        return redirect(
+            url_for('uploader_views.pipeline_data_upload_failed', slug=slug, file_id=file_id)
+        )
+
     return render_uploader_template(
         'pipeline_data_uploaded.html',
         pipeline=pipeline,
@@ -291,3 +297,23 @@ def progress(file_id):
         response['progress'] = '100'
         response['info'] = 'Sorry, there is a problem with the service. Try again later.'
     return response
+
+
+@uploader_views.route('/data/<slug>/uploaded/<file_id>/failed/')
+@login_required
+def pipeline_data_upload_failed(slug, file_id):
+    pipeline = get_object_or_404(Pipeline, slug=slug)
+    pipeline_data_file = get_object_or_404(PipelineDataFile, pipeline=pipeline, id=file_id)
+    schema_parts = pipeline.pipeline_schema.split('.')
+    if len(schema_parts) != 2:
+        raise BadRequest("Invalid schema for this pipeline.")
+    data_workspace_schema_name = schema_parts[0]
+    data_workspace_table_name = schema_parts[1]
+    file_id = pipeline_data_file.id
+    return render_uploader_template(
+        'pipeline_data_upload_failed.html',
+        pipeline=pipeline,
+        file_id=file_id,
+        data_workspace_schema_name=data_workspace_schema_name,
+        data_workspace_table_name=data_workspace_table_name,
+    )


### PR DESCRIPTION
At the moment, pipeline failures are reported within a green Design
System panel component, which is the same pattern we use for success of
the pipeline. This makes it harder for users to understand the end
result of a pipeline because it's easy to scan the page, see the green
banner, and expect success. We add a separate page for failures states
here to highlight the issue and provide a recommendation - to try
ingesting again.

![image](https://user-images.githubusercontent.com/2920760/113123149-39af8880-920c-11eb-8478-0c289a31f8ab.png)
