### PR TITLE
feat: older CompaniesHouseAccounts pipeline ingest to _legacy table

### DIFF
--- a/app/commands/dev/datafiles_to_s3_by_source.py
+++ b/app/commands/dev/datafiles_to_s3_by_source.py
@@ -11,7 +11,7 @@ from app.downloader.web.hmrc import HMRCExporters
 from app.downloader.web.ons import ONSPostcodeDirectory
 
 arg_to_downloader_info_list = {
-    'companies_house.accounts': (CompaniesHouseAccounts, 'companies_house/accounts/'),
+    'companies_house.accounts_legacy': (CompaniesHouseAccounts, 'companies_house/accounts/'),
     'hmrc.exporters': (HMRCExporters, 'hmrc/exporters/'),
     'ons.postcode_directory': (ONSPostcodeDirectory, 'ons/postcode_directory/'),
 }

--- a/app/etl/organisation/companies_house.py
+++ b/app/etl/organisation/companies_house.py
@@ -18,7 +18,7 @@ from app.etl.pipeline_type.incremental_data import L0IncrementalDataPipeline
 class CompaniesHouseAccountsPipeline(L0IncrementalDataPipeline):
 
     organisation = 'companies_house'
-    dataset = 'accounts'
+    dataset = 'accounts_legacy'
 
     _l0_data_column_types = [
         ('run_code', 'text'),

--- a/tests/commands/dev/test_datafiles_to_db_by_source.py
+++ b/tests/commands/dev/test_datafiles_to_db_by_source.py
@@ -454,7 +454,7 @@ class TestDataFileToDBBySource:
                 None,
             ),
             (
-                ['--companies_house.accounts', '--force'],
+                ['--companies_house.accounts_legacy', '--force'],
                 [
                     {
                         'continue_transform': False,

--- a/tests/commands/dev/test_datafiles_to_s3_by_source.py
+++ b/tests/commands/dev/test_datafiles_to_s3_by_source.py
@@ -23,7 +23,7 @@ class TestDownloadToS3BySource:
                 None,
             ),
             (
-                ['--companies_house.accounts'],
+                ['--companies_house.accounts_legacy'],
                 1,
                 True,
                 None,

--- a/tests/etl/test_companies_house_accounts.py
+++ b/tests/etl/test_companies_house_accounts.py
@@ -207,7 +207,7 @@ def test_trigger_dataflow_dag(mock_api_request, mocker, app):
         {'id': 'test_id', 'key': 'test_key', 'algorithm': 'sha256'},
         {
             'conf': {
-                'data_uploader_schema_name': 'companies_house.accounts',
+                'data_uploader_schema_name': 'companies_house.accounts_legacy',
                 'data_uploader_table_name': 'L0',
             }
         },


### PR DESCRIPTION
There is decreasing confidence in the older v1 Companies House accounts pipeline within the data-store-service, and so this will now ingest to a _legacy table in order to use the data for comparison, but to make the newer incremental pipeline ingest to the main accounts table. This means that the data ingested using stream-read-xbrl can be used within the Export Propensity pipeline.