### PR TITLE
fix: bump to SQLAlchemy 2 and related packages to allow to build and pass tests

### DIFF
--- a/app/api/views/dit_reference_postcodes.py
+++ b/app/api/views/dit_reference_postcodes.py
@@ -33,9 +33,9 @@ class DitReferencePostcodeView(View):
                 [field for field, _ in DITReferencePostcodesPipeline._l1_data_column_types]
             )}
             from {DITReferencePostcodesL1.get_fq_table_name()}
-            where lower(replace(postcode, ' ', '')) = %s
+            where lower(replace(postcode, ' ', '')) = :postcode
             limit 1
         '''
-        df = flask_app.dbi.execute_query(sql_query, data=[postcode], df=True)
+        df = flask_app.dbi.execute_query(sql_query, data={'postcode': postcode}, df=True)
         web_dict = to_web_dict(df, orientation)
         return flask_app.make_response(web_dict)

--- a/app/api/views/get_table.py
+++ b/app/api/views/get_table.py
@@ -27,7 +27,7 @@ def table_valid(view_func):
         schema = kwargs['schema']
         table_name = kwargs['table_name']
 
-        table_exists = flask_app.db.engine.has_table(table_name, schema)
+        table_exists = Inspector.from_engine(flask_app.db.engine).has_table(table_name, schema)
         if not table_exists or schema in [
             'pg_toast',
             'pg_temp_1',

--- a/app/etl/organisation/dit.py
+++ b/app/etl/organisation/dit.py
@@ -1,5 +1,7 @@
 from io import BytesIO
 
+from sqlalchemy import text
+
 from app.etl.pipeline_type.incremental_data import L1IncrementalDataPipeline
 from app.etl.pipeline_type.snapshot_data import L1SnapshotDataPipeline
 
@@ -153,7 +155,7 @@ class DITEUCountryMembershipPipeline(L1SnapshotDataPipeline):
                     WHERE datafile_created = '{datafile_name}') AS sq
             JOIN LATERAL json_each_text(sq.line) ON (key ~ '^[1-2]+');
         """
-        self.dbi.execute_statement(stmt)
+        self.dbi.execute_statement(text(stmt))
 
 
 class DITReferencePostcodesPipeline(L1SnapshotDataPipeline):

--- a/app/etl/organisation/world_bank.py
+++ b/app/etl/organisation/world_bank.py
@@ -4,6 +4,7 @@ from multiprocessing.pool import ThreadPool as Pool
 
 import psycopg2
 from flask import current_app as flask_app
+from sqlalchemy import text
 from tqdm import tqdm
 
 from app.etl.organisation.comtrade import ComtradeCountryCodeAndISOPipeline
@@ -75,7 +76,7 @@ class WorldBankBoundRatesPipeline(L1SnapshotDataPipeline):
             ORDER BY {grouping}, RIGHT(nomen_code,1)::int DESC
             ON CONFLICT (data_source_row_id) DO NOTHING
         """
-        self.dbi.execute_statement(stmt)
+        self.dbi.execute_statement(text(stmt))
 
 
 class WorldBankTariffPipeline(L1IncrementalDataPipeline):
@@ -170,7 +171,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
                 CREATE INDEX IF NOT EXISTS "{self.L1_TABLE}.temp_{field}_idx"
                 ON {self._l1_temp_table} USING hash ({field});
             """
-            self.dbi.execute_statement(stmt, raise_if_fail=True)
+            self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     def finish_processing(self):
         # swap tables to minimize api downtime
@@ -613,7 +614,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
             from required_countries
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_country_dictionary_view(self):
@@ -641,7 +642,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
             )
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_spine_view(self):
@@ -685,7 +686,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
             where reporter != partner
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_all_tariffs_view(self):
@@ -732,7 +733,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
             full join mfn_tariffs t2 using (product, year, reporter, partner) -- only 0 partner
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_eu_countries_view(self):
@@ -762,7 +763,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
             order by t2.iso_number, t1.year
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_eu_reporter_rates_view(self):
@@ -829,7 +830,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
             using (product, year, partner)
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_tariffs_with_eu_reporter_rates_view(self):
@@ -882,7 +883,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
         CREATE INDEX
             ON {self._fq(self.tariffs_with_eu_reporter_rates_vn)} (product);
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_eu_partner_rates_view(self):
@@ -908,7 +909,7 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
         CREATE INDEX
             ON {self._fq(self.eu_partner_rates_vn)} (product);
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     @timeit
     def _create_tariffs_with_world_partner_rates_view(self):
@@ -944,4 +945,4 @@ class WorldBankTariffTransformPipeline(L1IncrementalDataPipeline):
         CREATE INDEX
             ON {self._fq(self.tariffs_with_world_partner_rates_vn)} (product);
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)

--- a/app/etl/pipeline_type/base.py
+++ b/app/etl/pipeline_type/base.py
@@ -3,6 +3,7 @@ from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 
 from flask import current_app as flask_app
+from sqlalchemy import text
 
 
 class classproperty(object):
@@ -56,7 +57,7 @@ class DataPipeline(metaclass=ABCMeta):
             )
         else:
             self.dbi.execute_statement(
-                "SET statement_timeout TO '20h' "
+                text("SET statement_timeout TO '20h' ")
             )  # If a query takes longer over 20hours, stop it!
             if self.organisation and self.dataset:
                 self._create_schema_if_not_exists(self.schema)

--- a/app/etl/pipeline_type/incremental_data.py
+++ b/app/etl/pipeline_type/incremental_data.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 
+from sqlalchemy import text
+
 from app.etl.pipeline_type.base import LDataPipeline
 from app.utils import trigger_dataflow_dag
 
@@ -66,13 +68,13 @@ class L0IncrementalDataPipeline(LDataPipeline):
             self.dbi.drop_table(table_name)
         columns = ','.join(f'{c} {t}' for c, t in column_types)
         stmt = f'CREATE TABLE IF NOT EXISTS {table_name} ({columns})'
-        self.dbi.execute_statement(stmt)
+        self.dbi.execute_statement(text(stmt))
 
     def _create_sequence(self, sequence_name, drop_existing=False):
         if drop_existing:
             self.dbi.drop_sequence(sequence_name)
         stmt = f'CREATE SEQUENCE IF NOT EXISTS {sequence_name}'
-        self.dbi.execute_statement(stmt)
+        self.dbi.execute_statement(text(stmt))
 
     # append L0.temp TO L0
     def append_l0_temp_to_l0(self, datafile_name):
@@ -92,7 +94,7 @@ class L0IncrementalDataPipeline(LDataPipeline):
                 {selection}
             FROM {self._l0_temp_table}
         """
-        self.dbi.execute_statement(stmt)
+        self.dbi.execute_statement(text(stmt))
 
     def trigger_dataflow_dag(self):
         return trigger_dataflow_dag(self.schema, self.L0_TABLE)
@@ -184,7 +186,7 @@ class L1IncrementalDataPipeline(L0IncrementalDataPipeline):
                 {selection}
             FROM {self._l0_temp_table}
         """
-        self.dbi.execute_statement(stmt)
+        self.dbi.execute_statement(text(stmt))
 
     def trigger_dataflow_dag(self):
         return trigger_dataflow_dag(self.schema, self.L1_TABLE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-alembic==1.4.3
+alembic==1.12.1
     # via flask-migrate
 appnope==0.1.3
     # via ipython
@@ -242,7 +242,7 @@ packaging==20.1
     # via
     #   pytest
     #   spacy
-pandas==1.5.1
+pandas==2.1.2
     # via
     #   -r requirements.in
     #   data-engineering-common
@@ -313,9 +313,8 @@ pytest-cov==2.10.1
     #   data-engineering-common
 pytest-mock==3.3.1
     # via -r requirements.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
-    #   alembic
     #   botocore
     #   faker
     #   freezegun
@@ -323,8 +322,6 @@ python-dateutil==2.8.1
     #   tableschema
 python-dotenv==0.14.0
     # via data-engineering-common
-python-editor==1.0.4
-    # via alembic
 python-slugify==4.0.1
     # via -r requirements.in
 pytz==2020.1
@@ -373,7 +370,6 @@ six==1.14.0
     #   pip-tools
     #   pyrsistent
     #   python-dateutil
-    #   sqlalchemy-utils
     #   tableschema
     #   tabulator
 smart-open==5.2.1
@@ -386,7 +382,7 @@ spacy-legacy==3.0.10
     # via spacy
 spacy-loggers==1.0.3
     # via spacy
-sqlalchemy==1.4.42
+sqlalchemy==2.0.23
     # via
     #   -r requirements.in
     #   alembic
@@ -395,7 +391,7 @@ sqlalchemy==1.4.42
     #   sqlalchemy-utils
     #   tabulator
     #   wtforms-sqlalchemy
-sqlalchemy-utils==0.37.2
+sqlalchemy-utils==0.41.1
     # via
     #   -r requirements.in
     #   data-engineering-common
@@ -435,7 +431,12 @@ typer==0.4.2
     #   pathy
     #   spacy
 typing-extensions==4.8.0
-    # via black
+    # via
+    #   alembic
+    #   black
+    #   sqlalchemy
+tzdata==2023.3
+    # via pandas
 tzlocal==2.0.0
     # via apscheduler
 uktrade-data-tools @ git+https://github.com/uktrade/dt08-data-tools.git

--- a/tests/etl/test_world_bank_tariff.py
+++ b/tests/etl/test_world_bank_tariff.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from data_engineering.common.tests.conftest import create_tables
 from datatools.io.fileinfo import FileInfo
+from sqlalchemy import text
 
 from app.etl.organisation.world_bank import (
     WorldBankTariffPipeline,
@@ -136,7 +137,7 @@ class TestWorldBankTariffPipeline:
         add_dit_eu_country_membership,
     ):
         self.dbi = app_with_db.dbi
-        self.dbi.execute_statement('drop table if exists "dit.baci"."L1" cascade;')
+        self.dbi.execute_statement(text('drop table if exists "dit.baci"."L1" cascade;'))
         create_tables(app_with_db)
         add_comtrade_country_code_and_iso(comtrade_countries)
         add_dit_eu_country_membership(eu_country_memberships)
@@ -776,7 +777,7 @@ def patch_required_countries(mocker, countries):
             from required_countries
         )
         """
-        self.dbi.execute_statement(stmt, raise_if_fail=True)
+        self.dbi.execute_statement(text(stmt), raise_if_fail=True)
 
     mocker.patch.object(
         WorldBankTariffTransformPipeline,


### PR DESCRIPTION
The data-engineering-common project, that is a dependency of this project, requires SQLAlchemy >= 2.0.0 as of https://github.com/uktrade/data-engineering-common/pull/34. So in order for this project to build successfully, we need SQLAlchemy >= 2.0.0

This was done by running (after a bit of trial and error):

```shell
pip-compile --upgrade-pacakge alembic --upgrade-package sqlalchemy-utils --upgrade-package pandas==2.1.2
```

Which involves breaking changes to both SQLAlchemy and Pandas. Specifically now it seems to be necessary to:

- Go via the "inspect" API in SQLAlchemy to check if a table exists
- Wrap all SQL strings with SQLAlchemy's `text`
- Use named parameters in SQL strings and dictionaries for their values.