### PR TITLE
dev: make it possible again to run data-store-service locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,19 @@ ADD requirements.txt /tmp/requirements.txt
 ADD package.json package-lock.json ./
 
 RUN scripts/install_python_packages.sh
-RUN scripts/install_node.sh
+
+# Install node: based on https://stackoverflow.com/a/57546198/1319998
+ENV NODE_VERSION=14.16.1
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+
+# Install node packages
 RUN npm install
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ The backend is built in Python using the Flask framework. Authentication impleme
 
 ### Docker installation
 1. Copy `.envs/docker.env` to `.env`
-2. `docker-compose build`
-3. `docker-compose up`
-4. Go to http://localhost:5050/healthcheck
+2. `docker compose up --build`
+3. Go to http://localhost:5050/healthcheck
 
 Running postgres in docker now requires a mandatory environment variable called POSTGRES_PASSWORD. This must be added to your .env file.
 

--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-source ./scripts/functions.sh
-
-run "curl https://deb.nodesource.com/setup_10.x --output node.sh"
-run "bash node.sh -b"
-run "rm -f node.sh"
-run "apt-get install -y nodejs"


### PR DESCRIPTION
The previous node version would not install (erroring with messages about unsupported versions), and was not the same as the one running in CircleCI. Just changing the existing script to the same node version as in CircleCI also errored out, so an alternative, and hopefully more robust way is used. This now seems to work fine locally.

This deliberately does away with the separate script to install node - this isn't needed and makes it harder to see what's going on when you need to change things.

This also updates the command to run locally `from docker-compose` to `docker compose`, which is the current recommended way to run compose file.